### PR TITLE
fix: prevent raw exception exposure in error handlers

### DIFF
--- a/backend/common/errors.py
+++ b/backend/common/errors.py
@@ -1,6 +1,11 @@
+import logging
+import uuid
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_http_detail(detail: object) -> tuple[str, list[dict] | None]:
@@ -45,14 +50,29 @@ def register_exception_handlers(app: FastAPI) -> None:
         )
 
     @app.exception_handler(Exception)
-    async def unhandled_exception_handler(_: Request, exc: Exception):
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        # Generate a unique correlation ID so the error can be traced in server logs
+        # without exposing internal details to the client.
+        correlation_id = str(uuid.uuid4())
+
+        # Log the full exception server-side with the correlation ID for traceability.
+        logger.exception(
+            "Unhandled exception [correlation_id=%s] on %s %s",
+            correlation_id,
+            request.method,
+            request.url.path,
+            exc_info=exc,
+        )
+
+        # Return only a generic message + correlation ID to the client.
+        # Never expose str(exc) or stack traces to external callers.
         return JSONResponse(
             status_code=500,
             content={
                 "error": {
                     "code": "internal_server_error",
-                    "message": "Internal server error.",
-                    "details": [{"exception": str(exc)}],
+                    "message": "An unexpected error occurred. Please contact support if this persists.",
+                    "correlation_id": correlation_id,
                 }
             },
         )


### PR DESCRIPTION
## What changed
- `unhandled_exception_handler` now generates a `correlation_id` (`uuid4`) for every unhandled error
- Full exception + correlation ID is logged server-side via Python `logging`
- Client receives only: `{"code": "internal_server_error", "message": "An unexpected error occurred...", "correlation_id": "<uuid>"}`
- `str(exc)` is **never** returned to the client

## Why it changed
Closes #10. The previous handler returned `{"details": [{"exception": str(exc)}]}` which could leak internal stack traces, config values, or sensitive system details to API consumers.

## How to test
- Trigger a 500 error (e.g. raise an exception in a route)
- Confirm the response body contains `correlation_id` but NOT the raw exception message
- Confirm the server logs show the full exception with the matching `correlation_id`

Closes #10