### PR TITLE
fix: add hard guard preventing mock auth activation in production

### DIFF
--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -60,6 +60,7 @@ MOCK_USER = User(
 
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    verify_existence: bool = True,
 ) -> User:
     """
     FastAPI dependency that extracts and verifies the user from a Supabase JWT.
@@ -83,8 +84,6 @@ async def get_current_user(
 
     try:
         if not SUPABASE_JWT_SECRET:
-            # In dev mode with no secret and no token this path is unreachable
-            # (caught above). Reaching here means prod with missing secret.
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Authentication server misconfigured (missing JWT secret)",
@@ -92,9 +91,18 @@ async def get_current_user(
 
         # Decode and verify the Supabase JWT
         # Supabase uses HS256 by default, but newer projects use ES256 (ECC P-256)
+        key = SUPABASE_JWT_SECRET
+        try:
+            import json
+            trimmed_secret = SUPABASE_JWT_SECRET.strip()
+            if trimmed_secret.startswith('{') and trimmed_secret.endswith('}'):
+                key = json.loads(trimmed_secret)
+        except Exception:
+            key = SUPABASE_JWT_SECRET
+
         payload = jwt.decode(
             token,
-            SUPABASE_JWT_SECRET,
+            key,
             algorithms=["HS256", "ES256"],
             audience="authenticated",
         )
@@ -108,10 +116,20 @@ async def get_current_user(
                 detail="Invalid token payload",
             )
 
+        # --- DATABASE TRUTH CHECK ---
+        # If not in mock-auth mode, verify the user exists in our DB
+        if not _MOCK_AUTH_ACTIVE and verify_existence:
+            from database.supabase_client import supabase
+            user_check = supabase.table("user_settings").select("owner_id").eq("owner_id", user_id).execute()
+            if not user_check.data:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="User account has been deactivated or deleted.",
+                )
+
         return User(id=user_id, email=email)
 
     except JWTError as e:
-        # In mock-auth dev mode with a bad token, log and fall back to mock user.
         if _MOCK_AUTH_ACTIVE:
             logger.debug(
                 "Auth: Invalid JWT in BACKEND_DEV_MODE, continuing with MOCK_USER. Error: %s", e
@@ -133,3 +151,10 @@ async def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication token",
         )
+
+
+async def get_user_no_check(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> User:
+    """Dependency for endpoints that need auth but can skip the existence check (e.g. onboarding)."""
+    return await get_current_user(credentials, verify_existence=False)

--- a/backend/common/auth.py
+++ b/backend/common/auth.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import Optional
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -8,29 +9,68 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Configuration
-SUPABASE_JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET")
-# Mirror the frontend VITE_DEV_MODE
-DEV_MODE = os.getenv("VITE_DEV_MODE", "true").lower() == "true"
+logger = logging.getLogger(__name__)
 
-security = HTTPBearer(auto_error=not DEV_MODE)
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SUPABASE_JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET")
+
+# BACKEND_DEV_MODE is the authoritative toggle for mock auth.
+# It must be set explicitly — the frontend's VITE_DEV_MODE is NOT used here
+# to avoid accidental mock auth activation in production environments.
+BACKEND_DEV_MODE = os.getenv("BACKEND_DEV_MODE", "false").lower() == "true"
+
+# ---------------------------------------------------------------------------
+# Hard guard: Refuse mock auth if JWT secret is present.
+# This prevents a misconfigured production environment (e.g. BACKEND_DEV_MODE
+# accidentally set to true) from silently bypassing authentication.
+# ---------------------------------------------------------------------------
+if BACKEND_DEV_MODE and SUPABASE_JWT_SECRET:
+    logger.warning(
+        "⚠️  BACKEND_DEV_MODE=true but SUPABASE_JWT_SECRET is configured. "
+        "Mock auth is DISABLED — real JWT verification will be enforced. "
+        "To use mock auth, remove SUPABASE_JWT_SECRET from your environment."
+    )
+    # Force real JWT verification when the secret is present, even in dev mode.
+    _MOCK_AUTH_ACTIVE = False
+elif BACKEND_DEV_MODE:
+    logger.warning(
+        "⚠️  BACKEND_DEV_MODE=true and no SUPABASE_JWT_SECRET found. "
+        "Mock authentication is ACTIVE. Do NOT use this configuration in production."
+    )
+    _MOCK_AUTH_ACTIVE = True
+else:
+    _MOCK_AUTH_ACTIVE = False
+
+security = HTTPBearer(auto_error=not _MOCK_AUTH_ACTIVE)
+
 
 class User(BaseModel):
     id: str
     email: Optional[str] = None
 
-# Mock User for DEV_MODE
+
+# Mock User — only used when _MOCK_AUTH_ACTIVE is True
 MOCK_USER = User(
     id="00000000-0000-0000-0000-000000000000",
     email="dev@insightai.com"
 )
 
-async def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)) -> User:
+
+async def get_current_user(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+) -> User:
     """
     FastAPI dependency that extracts and verifies the user from a Supabase JWT.
-    If DEV_MODE is True and no token is provided, returns a mock user.
+
+    Authentication flow:
+      1. If BACKEND_DEV_MODE=true AND no SUPABASE_JWT_SECRET → return MOCK_USER (local dev only)
+      2. If BACKEND_DEV_MODE=true AND SUPABASE_JWT_SECRET is set → enforce real JWT (hard guard)
+      3. Production: always enforce real JWT, never fall back to mock
     """
-    if DEV_MODE and not credentials:
+    # Allow mock auth only when explicitly activated with no secret present
+    if _MOCK_AUTH_ACTIVE and not credentials:
         return MOCK_USER
 
     if not credentials:
@@ -40,13 +80,11 @@ async def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] =
         )
 
     token = credentials.credentials
-    
+
     try:
         if not SUPABASE_JWT_SECRET:
-            # If we don't have the secret, we can't verify locally.
-            # In a real production environment, this would be a configuration error.
-            if DEV_MODE:
-                return MOCK_USER
+            # In dev mode with no secret and no token this path is unreachable
+            # (caught above). Reaching here means prod with missing secret.
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Authentication server misconfigured (missing JWT secret)",
@@ -55,35 +93,43 @@ async def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] =
         # Decode and verify the Supabase JWT
         # Supabase uses HS256 by default, but newer projects use ES256 (ECC P-256)
         payload = jwt.decode(
-            token, 
-            SUPABASE_JWT_SECRET, 
-            algorithms=["HS256", "ES256"], 
-            audience="authenticated"
+            token,
+            SUPABASE_JWT_SECRET,
+            algorithms=["HS256", "ES256"],
+            audience="authenticated",
         )
-        
+
         user_id: str = payload.get("sub")
         email: str = payload.get("email")
-        
+
         if user_id is None:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid token payload",
             )
-            
+
         return User(id=user_id, email=email)
 
     except JWTError as e:
-        if DEV_MODE:
-            print(f"Auth Trace: Invalid JWT provided, but continuing with MOCK_USER because DEV_MODE=true. Error: {e}")
+        # In mock-auth dev mode with a bad token, log and fall back to mock user.
+        if _MOCK_AUTH_ACTIVE:
+            logger.debug(
+                "Auth: Invalid JWT in BACKEND_DEV_MODE, continuing with MOCK_USER. Error: %s", e
+            )
             return MOCK_USER
-            
+
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Could not validate credentials: {str(e)}",
+            detail="Could not validate credentials",
         )
-    except Exception as e:
-        if DEV_MODE:
+
+    except HTTPException:
+        raise
+
+    except Exception:
+        if _MOCK_AUTH_ACTIVE:
             return MOCK_USER
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication token"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
         )


### PR DESCRIPTION
Incorporated directly into main via commit on 2026-04-19. The `BACKEND_DEV_MODE` hard guard + merged `verify_existence` and `get_user_no_check` features were applied directly to `backend/common/auth.py` on main due to a conflicting diverged branch. PR closed — changes are live on main.