### PR TITLE
chore: add GitHub Actions CI pipeline for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ------------------------------------------------------------------ #
+  # Backend: Lint + Type Check + Tests                                  #
+  # ------------------------------------------------------------------ #
+  backend:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt flake8 mypy
+
+      - name: Lint (flake8)
+        run: flake8 . --max-line-length=100 --exclude=__pycache__,.venv
+
+      - name: Type check (mypy)
+        run: mypy . --ignore-missing-imports --exclude tests
+
+      - name: Run unit tests (pytest)
+        run: pytest tests/ -v -m "not integration"
+
+  # ------------------------------------------------------------------ #
+  # Frontend: Lint + Type Check                                         #
+  # ------------------------------------------------------------------ #
+  frontend:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (eslint)
+        run: npx eslint src --ext .ts,.tsx --max-warnings 0
+
+      - name: Type check (tsc)
+        run: npx tsc --noEmit


### PR DESCRIPTION
## What changed
Created `.github/workflows/ci.yml` with two jobs:

**`backend` job:**
- Runs on every push/PR to `main`
- Sets up Python 3.11, installs `requirements.txt` + `flake8` + `mypy`
- Runs `flake8` (max line length 100)
- Runs `mypy` for type checking
- Runs `pytest tests/ -m "not integration"` (unit tests only, no DB required)

**`frontend` job:**
- Sets up Node.js 20, runs `npm ci`
- Runs `eslint` on `src/` (`.ts`, `.tsx` files)
- Runs `tsc --noEmit` for type checking

## Why it changed
Closes #13. Without CI, every PR is a manual review with no automated quality gate. Breaking changes, type errors, and lint violations can merge silently.

## How to test
- Open any PR → GitHub Actions should automatically trigger both jobs
- Check the PR page for green ✅ checkmarks before merging

Closes #13