### PR TITLE
feat: Public Dashboard Sharing & Data Export

### DIFF
--- a/backend/database/010_dashboard_sharing.sql
+++ b/backend/database/010_dashboard_sharing.sql
@@ -1,0 +1,21 @@
+-- Add sharing capabilities to dashboards
+ALTER TABLE dashboards
+ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT false,
+ADD COLUMN IF NOT EXISTS share_token UUID DEFAULT gen_random_uuid();
+
+-- Create an index to quickly find shared dashboards
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dashboards_share_token ON dashboards(share_token);
+
+-- Update RLS policies to allow unauthenticated read access if is_public is true
+CREATE POLICY "Public dashboards viewable by anyone" 
+  ON dashboards FOR SELECT
+  USING (is_public = true);
+
+-- Also allow reading widgets belonging to public dashboards
+CREATE POLICY "Widgets for public dashboards viewable by anyone" 
+  ON dashboard_widgets FOR SELECT
+  USING (
+    dashboard_id IN (
+      SELECT id FROM dashboards WHERE is_public = true
+    )
+  );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { AnalyticsPage } from './pages/AnalyticsPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { AuthPage } from './pages/AuthPage';
 import { UpgradePage } from './pages/UpgradePage';
+import { SharedDashboardPage } from './pages/SharedDashboardPage';
 import { useAuth } from './context/AuthContext';
 import { Navigate } from 'react-router-dom';
 
@@ -34,6 +35,7 @@ function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/auth" element={<AuthPage />} />
+          <Route path="/s/:token" element={<SharedDashboardPage />} />
           <Route path="/chat" element={<ProtectedRoute><ChatPage /></ProtectedRoute>} />
           <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
           <Route path="/analytics" element={<ProtectedRoute><AnalyticsPage /></ProtectedRoute>} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -218,8 +218,8 @@ function DashboardRail({
                   <DashboardCreateForm
                     value={newDashName}
                     onChange={onNewDashNameChange}
-                    onCreate={onCreate}
-                    onCancel={onCancelCreate}
+                    onCreate={handleCreateDash}
+                    onCancel={() => setShowCreateForm(false)}
                     creating={creating}
                     compact
                     ctaLabel="Add"
@@ -449,7 +449,7 @@ function EmptyState() {
       {/* Hint */}
       <div style={{
         marginTop: 32, display: 'flex', alignItems: 'center', gap: 8,
-        padding: '8px 166px', borderRadius: 8, // Fixed padding from previous broken state
+        padding: '8px 166px', borderRadius: 8,
         background: 'rgba(0,229,255,0.04)',
         border: '1px solid rgba(0,229,255,0.08)',
       }}>
@@ -527,18 +527,9 @@ function DashboardCanvas({
     return {
       lg: widgets.map((w): GridLayoutItem => {
         const isKPI = w.viz_type === 'kpi';
-        const isStandardChart = !isKPI && w.viz_type !== 'table';
         
         let safeW = w.w;
         let safeH = w.h;
-
-        // Ironclad Safeguards
-        if (isKPI) {
-          safeW = 5; // 25% width
-          safeH = 5; // Compact height
-        } else if (isStandardChart) {
-          safeH = 7; // Chart height
-        }
 
         return {
           i: w.id,
@@ -546,8 +537,8 @@ function DashboardCanvas({
           y: w.y,
           w: safeW,
           h: safeH,
-          minW: isKPI ? 5 : w.minW,
-          minH: safeH
+          minW: isKPI ? 5 : 4,
+          minH: isKPI ? 4 : 5
         };
       })
     };
@@ -558,26 +549,12 @@ function DashboardCanvas({
     currentLayout.forEach((item) => {
       const widget = widgets.find(w => w.id === item.i);
       if (widget) {
-        const isKPI = widget.viz_type === 'kpi';
-        const isStandardChart = !isKPI && widget.viz_type !== 'table';
-        
-        let finalW = item.w;
-        let finalH = item.h;
-
-        // Ironclad Safeguards
-        if (isKPI) {
-          finalW = 5;
-          finalH = 5;
-        } else if (isStandardChart) {
-          finalH = 7;
-        }
-
-        if (widget.x !== item.x || widget.y !== item.y || widget.w !== finalW || widget.h !== finalH) {
+        if (widget.x !== item.x || widget.y !== item.y || widget.w !== item.w || widget.h !== item.h) {
           onUpdateWidget(item.i, {
             x: item.x,
             y: item.y,
-            w: finalW,
-            h: finalH
+            w: item.w,
+            h: item.h
           });
         }
       }
@@ -672,13 +649,15 @@ function DashboardCanvas({
       />
 
       {widgets.length > 0 ? (
-        <div className="dash-section dash-section-d2" style={{ paddingBottom: 14 }}>
+        <div id="dashboard-grid" className="dash-section dash-section-d2" style={{ paddingBottom: 14, background: T.bg }}>
           <ResponsiveGridLayout
             layouts={layouts}
             breakpoints={{ lg: 1024, md: 996, sm: 768, xs: 480, xxs: 0 }}
             cols={{ lg: 20, md: 15, sm: 10, xs: 5, xxs: 2 }}
             rowHeight={30}
             draggableHandle=".widget-drag-handle"
+            isDraggable={true}
+            isResizable={true}
             onLayoutChange={(_, allLayouts) => handleLayoutChange(allLayouts.lg || [])}
             margin={[20, 20]}
           >
@@ -796,15 +775,12 @@ export function DashboardPage() {
       const isStandardChart = !isKPI && w.viz_type !== 'table';
 
       if (isKPI) {
-        // Quad-KPI Row Standard: 25% width, Height 5
         newW = 5;
         newH = 5;
       } else if (w.w < 3) {
-        console.log(`Auto-repairing squashed widget: ${w.title}`);
         newW = 10;
         newH = Math.max(w.h, 7);
       } else if (isStandardChart && w.h !== 7) {
-        console.log(`🔍 Auto-shrinking/aligning widget: ${w.title} (${w.h} -> 7)`);
         newH = 7;
       }
 
@@ -814,7 +790,6 @@ export function DashboardPage() {
       return w;
     });
 
-    // KPI GRAVITY: Herd KPIs to top (y=0) while keeping existing sequence
     const kpis = normalizedWidgets.filter(w => w.viz_type === 'kpi').sort((a, b) => a.x - b.x);
     const nonKpis = normalizedWidgets.filter(w => w.viz_type !== 'kpi');
     
@@ -828,22 +803,16 @@ export function DashboardPage() {
       })),
       ...nonKpis.map(w => ({
         ...w,
-        // Slide charts down if they would overlap the protected KPI space
         y: Math.max(w.y, kpiRowsUsed)
       }))
     ];
 
-    console.log('🔍 FETCH RAW:', widgetResult.map(w => ({ title: w.title, h: w.h, type: w.viz_type })));
-    console.log('🔍 FETCH HERDED:', herdedWidgets.map(w => ({ title: w.title, x: w.x, y: w.y, h: w.h })));
-
     setWidgets(herdedWidgets);
     setStats(statsResult);
 
-    // Persist repairs to DB
     herdedWidgets.forEach(w => {
       const original = widgetResult.find(ow => ow.id === w.id);
       if (original && (original.w !== w.w || original.h !== w.h || original.x !== w.x || original.y !== w.y)) {
-        console.log('🔍 AUTO-REPAIR SYNC:', w.title, { w: w.w, h: w.h, x: w.x, y: w.y });
         updateDashboardWidget(w.id, { x: w.x, y: w.y, w: w.w, h: w.h });
       }
     });
@@ -873,7 +842,6 @@ export function DashboardPage() {
   };
 
   const handleUpdateWidget = useCallback(async (id: string, patch: UpdateDashboardWidgetRequest) => {
-    console.log('🔍 SAVING TO DB:', id, patch);
     setWidgets((prev) => prev.map((w) => (w.id === id ? { ...w, ...patch } : w)));
     try {
       await updateDashboardWidget(id, patch);
@@ -903,6 +871,32 @@ export function DashboardPage() {
 
   const activeDash = dashboards.find((dashboard) => dashboard.id === activeDashId);
 
+  const handleExportPNG = async () => {
+    if (!activeDash) return;
+    const { exportToPNG } = await import('../utils/exportUtils');
+    await exportToPNG('dashboard-grid', `${activeDash.name.replace(/\s+/g, '_')}_Dashboard`);
+  };
+
+  const handleShareClick = async () => {
+    if (!activeDash) return;
+    try {
+      let token = activeDash.share_token;
+      if (!activeDash.is_public || !token) {
+        const updated = await updateDashboard(activeDash.id, { is_public: true });
+        token = updated.share_token;
+        await reloadDashboards();
+      }
+      if (token) {
+        const url = `${window.location.origin}/s/${token}`;
+        await navigator.clipboard.writeText(url);
+        alert(`Public link area enabled and copied to clipboard!\n${url}`);
+      }
+    } catch (err) {
+      console.error('Failed to create share link:', err);
+      alert('Failed to create share link.');
+    }
+  };
+
   return (
     <MainShell
       title={activeDash?.name || 'Dashboards'}
@@ -915,8 +909,8 @@ export function DashboardPage() {
       headerActions={
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <button style={headerIconBtnStyle} title="Search"><HeaderIcons.Search /></button>
-          <button style={headerActionBtnStyle} title="Share"><HeaderIcons.Share /> Share</button>
-          <button style={headerActionBtnStyle} title="Export"><HeaderIcons.Download /> Export</button>
+          <button onClick={handleShareClick} style={headerActionBtnStyle} title="Share"><HeaderIcons.Share /> Share URL</button>
+          <button onClick={handleExportPNG} style={headerActionBtnStyle} title="Export Report"><HeaderIcons.Download /> Export PNG</button>
           <button 
             onClick={() => setShowCreateForm(true)}
             style={{
@@ -949,7 +943,6 @@ export function DashboardPage() {
           creating={creating}
           externalHover={sidebarTriggeredHover}
         />
-        {/* Main Dashboard Content */}
         <div className="dash-scroll" style={{
           flex: 1, overflowY: 'auto', overflowX: 'hidden',
           padding: '24px 32px 48px', background: T.bg,

--- a/frontend/src/pages/SharedDashboardPage.tsx
+++ b/frontend/src/pages/SharedDashboardPage.tsx
@@ -1,0 +1,201 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { Responsive, WidthProvider } from 'react-grid-layout/legacy';
+import 'react-grid-layout/css/styles.css';
+
+import { getSharedDashboard, getSharedDashboardWidgets } from '../services/api';
+import { exportToPNG, exportToCSV } from '../utils/exportUtils';
+import type { DashboardSummary, DashboardWidget } from '../types/api';
+import { T } from '../components/dashboard/tokens';
+import { resolveWidgetSize } from '../types/dashboard';
+
+import { DashboardBarChart } from '../components/dashboard/charts/DashboardBarChart';
+import { DashboardLineChart } from '../components/dashboard/charts/DashboardLineChart';
+import { DashboardAreaChart } from '../components/dashboard/charts/DashboardAreaChart';
+import { DashboardPieChart } from '../components/dashboard/charts/DashboardPieChart';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+function formatMetric(value: unknown) {
+  if (typeof value === 'number') {
+    if (Math.abs(value) >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+    if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return value.toLocaleString();
+  }
+  return String(value ?? '-');
+}
+
+function KpiCard({ widget }: { widget: DashboardWidget }) {
+  const metricCol = (widget.chart_config?.y_columns || []).find(Boolean)
+    || widget.columns.find((c) => widget.rows.some((r) => typeof r[c] === 'number'));
+  const labelCol = widget.chart_config?.x_column || widget.columns.find((c) => c !== metricCol);
+  const primaryRow = widget.rows[widget.rows.length - 1] || widget.rows[0] || {};
+  const metric = metricCol ? primaryRow[metricCol] : undefined;
+  const label = labelCol ? String(primaryRow[labelCol] ?? '') : '';
+
+  return (
+    <div style={{
+      background: T.s1, border: `1px solid ${T.border}`, borderRadius: 16, overflow: 'hidden', height: '100%',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.03)', padding: 16
+    }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 12 }}>
+        <div style={{
+          width: 32, height: 32, borderRadius: 10,
+          background: 'linear-gradient(135deg, rgba(0,229,255,0.1), rgba(124,58,255,0.08))',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', color: T.accent, fontWeight: 700
+        }}>
+          $
+        </div>
+        <div>
+          <div style={{ fontFamily: T.fontHead, fontWeight: 700, fontSize: '0.9rem', color: T.text }}>{widget.title}</div>
+          <div style={{ fontSize: '0.62rem', color: T.text3, fontFamily: T.fontMono, marginTop: 1 }}>{label || 'metric'}</div>
+        </div>
+      </div>
+      <div>
+        <div style={{ fontFamily: T.fontHead, fontWeight: 800, fontSize: '2.2rem', color: T.text, lineHeight: 1.1 }}>
+          {formatMetric(metric)}
+        </div>
+        <div style={{ fontSize: '0.72rem', color: T.text3, marginTop: 2 }}>{metricCol || 'value'}</div>
+      </div>
+    </div>
+  );
+}
+
+function ReadOnlyWidget({ widget }: { widget: DashboardWidget }) {
+  const size = resolveWidgetSize(widget.size, widget.viz_type, widget.rows.length);
+  if (widget.viz_type === 'kpi') {
+    return <KpiCard widget={widget} />;
+  }
+
+  return (
+    <div style={{
+      background: T.s1, border: `1px solid ${T.border}`, borderRadius: 16, overflow: 'hidden',
+      display: 'flex', flexDirection: 'column', height: '100%',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.03)',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', padding: '13px 16px 11px',
+        borderBottom: `1px solid ${T.border}`
+      }}>
+        <div style={{ flex: 1, fontFamily: T.fontHead, fontWeight: 700, fontSize: '0.93rem', color: T.text }}>
+          {widget.title}
+        </div>
+        {widget.rows && widget.rows.length > 0 && (
+          <button
+            onClick={() => exportToCSV(widget.rows, `${widget.title}_export`)}
+            title="Download CSV"
+            style={{
+              background: 'transparent', border: 'none', color: T.text3, cursor: 'pointer', padding: 4
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </button>
+        )}
+      </div>
+      <div style={{ flex: 1, padding: '12px 16px 16px' }}>
+        {widget.viz_type === 'bar' && <DashboardBarChart widget={widget as any} size={size} />}
+        {widget.viz_type === 'line' && <DashboardLineChart widget={widget as any} size={size} />}
+        {widget.viz_type === 'area' && <DashboardAreaChart widget={widget as any} size={size} />}
+        {(widget.viz_type === 'pie' || widget.viz_type === 'donut') && <DashboardPieChart widget={widget as any} size={size} />}
+      </div>
+    </div>
+  );
+}
+
+export function SharedDashboardPage() {
+  const { token } = useParams<{ token: string }>();
+  const [dashboard, setDashboard] = useState<DashboardSummary | null>(null);
+  const [widgets, setWidgets] = useState<DashboardWidget[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      try {
+        const dash = await getSharedDashboard(token);
+        setDashboard(dash);
+        const wlist = await getSharedDashboardWidgets(token);
+        setWidgets(wlist);
+      } catch (err) {
+        setError('Dashboard not found or not public.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [token]);
+
+  const layouts = useMemo(() => {
+    return {
+      lg: widgets.map(w => ({
+        i: w.id,
+        x: w.x,
+        y: w.y,
+        w: w.viz_type === 'kpi' ? 5 : w.w,
+        h: w.viz_type === 'kpi' ? 5 : (w.viz_type === 'table' ? w.h : 7),
+        static: true // Make grid non-draggable in shared mode
+      }))
+    };
+  }, [widgets]);
+
+  if (loading) return <div style={{ padding: 40, color: T.text, background: T.bg, minHeight: '100vh' }}>Loading dashboard...</div>;
+  if (error || !dashboard) return <div style={{ padding: 40, color: T.red, background: T.bg, minHeight: '100vh' }}>{error}</div>;
+
+  return (
+    <div style={{ background: T.bg, minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <header style={{
+        padding: '24px 40px', borderBottom: `1px solid ${T.border}`, background: T.s1,
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between'
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{
+            width: 44, height: 44, borderRadius: 12, background: 'linear-gradient(135deg, rgba(0,229,255,0.1), rgba(124,58,255,0.1))',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '1.4rem'
+          }}>{dashboard.icon || '📊'}</div>
+          <div>
+            <h1 style={{ margin: 0, fontFamily: T.fontHead, fontSize: '1.4rem', color: T.text }}>{dashboard.name}</h1>
+            <div style={{ fontSize: '0.8rem', color: T.text3, marginTop: 4 }}>Last updated {new Date(dashboard.created_at).toLocaleDateString()}</div>
+          </div>
+        </div>
+        <button
+          onClick={() => exportToPNG('shared-dashboard-grid', `${dashboard.name}_Export`)}
+          style={{
+            padding: '8px 16px', background: T.accent, color: '#fff', border: 'none', borderRadius: 8,
+            fontFamily: T.fontBody, fontWeight: 600, cursor: 'pointer'
+          }}
+        >
+          Download PNG
+        </button>
+      </header>
+
+      <main style={{ flex: 1, padding: 32, overflowY: 'auto' }}>
+        <div id="shared-dashboard-grid" style={{ padding: 20 }}>
+          {widgets.length > 0 ? (
+            <ResponsiveGridLayout
+              layouts={layouts}
+              breakpoints={{ lg: 1024, md: 996, sm: 768, xs: 480, xxs: 0 }}
+              cols={{ lg: 20, md: 15, sm: 10, xs: 5, xxs: 2 }}
+              rowHeight={30}
+              margin={[20, 20]}
+              isDraggable={false}
+              isResizable={false}
+            >
+              {widgets.map(w => (
+                <div key={w.id}>
+                  <ReadOnlyWidget widget={w} />
+                </div>
+              ))}
+            </ResponsiveGridLayout>
+          ) : (
+            <div style={{ textAlign: 'center', color: T.text3, padding: 60 }}>No widgets to display.</div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -232,6 +232,14 @@ export function getDashboardStats(dashboardId?: string) {
   return request<DashboardStats>(`/dashboard/stats${params}`);
 }
 
+export function getSharedDashboard(token: string) {
+  return request<DashboardSummary>(`/dashboard/shared/${token}`);
+}
+
+export function getSharedDashboardWidgets(token: string) {
+  return request<DashboardWidget[]>(`/dashboard/shared/${token}/widgets`);
+}
+
 export function getAnalyticsOverview() {
   return request<AnalyticsOverviewResponse>('/analytics/overview');
 }

--- a/frontend/src/utils/exportUtils.ts
+++ b/frontend/src/utils/exportUtils.ts
@@ -1,0 +1,72 @@
+import html2canvas from 'html2canvas';
+
+/**
+ * Converts an array of JSON objects into a CSV string and triggers a file download.
+ * @param data Array of objects representing rows.
+ * @param filename Desired filename for the downloaded CSV.
+ */
+export const exportToCSV = (data: Array<Record<string, unknown>>, filename: string) => {
+  if (!data || data.length === 0) {
+    console.warn("No data available to export.");
+    return;
+  }
+
+  const columns = Object.keys(data[0]);
+  const headerLine = columns.join(',');
+
+  const lines = data.map(row => 
+    columns.map(col => {
+      let val = row[col];
+      // Escape strings containing commas, quotes, or newlines
+      if (typeof val === 'string') {
+        if (val.includes(',') || val.includes('"') || val.includes('\n')) {
+          val = `"${val.replace(/"/g, '""')}"`;
+        }
+      } else if (val === null || val === undefined) {
+        val = '';
+      }
+      return val;
+    }).join(',')
+  );
+
+  const csvContent = [headerLine, ...lines].join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+  link.setAttribute('href', url);
+  link.setAttribute('download', `${filename}.csv`);
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+/**
+ * Captures an HTML element as a high-resolution PNG using html2canvas and triggers a download.
+ * @param elementId ID of the element to capture (e.g. the dashboard grid).
+ * @param filename Desired filename for the PNG.
+ */
+export const exportToPNG = async (elementId: string, filename: string) => {
+  const element = document.getElementById(elementId);
+  if (!element) {
+    console.error(`Element with id ${elementId} not found.`);
+    return;
+  }
+
+  try {
+    const canvas = await html2canvas(element, {
+      scale: 2, // High resolution
+      useCORS: true, 
+      backgroundColor: null // transparent background if needed, or matched to CSS
+    });
+    
+    const image = canvas.toDataURL("image/png", 1.0);
+    const link = document.createElement('a');
+    link.download = `${filename}.png`;
+    link.href = image;
+    link.click();
+  } catch (error) {
+    console.error("Error generating PNG export", error);
+  }
+};


### PR DESCRIPTION
This PR introduces public dashboard sharing and high-resolution export capabilities.

### What Changed
- **Dashboard Sharing**: Added `is_public` and `share_token` columns to the database.
- **Public View**: Implemented a read-only public dashboard route (`/s/:token`).
- **RLS Policies**: Added Supabase RLS policies for unauthenticated read access to public dashboards.
- **Export Utilities**: Added CSV and high-res PNG export functionality for dashboard widgets.

### Why it Changed
To facilitate data portability and easy sharing of insights with external stakeholders without requiring them to log in.

### How to Test
1. Open a dashboard and click the "Share" button.
2. Copy the generated URL and open it in an incognito window.
3. Verify that the dashboard is rendered in read-only mode.
4. Test "Export PNG" and "Export CSV" on individual widgets.