### PR TITLE
Fix duplicate allow_headers keyword argument in CORS config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -126,7 +126,6 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_headers=["*"],
-    allow_headers=["*"],
     allow_methods=["*"],
     allow_credentials=True,
 )


### PR DESCRIPTION
Removed the duplicate `allow_headers=["*"]` argument in `backend/main.py` which was causing a `SyntaxError` and preventing the application from starting.

---
*PR created automatically by Jules for task [5126284790332914924](https://jules.google.com/task/5126284790332914924) started by @danishali778*