### PR TITLE
fix: resolve JSX syntax error in MessageBubble action bar

### DIFF
--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -172,8 +172,6 @@ export function MessageBubble({
 
             <button
               onClick={handleDashboardClick}
-            <button
-              onClick={handleDashboardClick}
               disabled={isSmartSaving}
               style={{
                 padding: '6px 12px', borderRadius: 8, border: `1px solid ${T.border}`,


### PR DESCRIPTION
This PR resolves a JSX syntax error in `MessageBubble.tsx` introduced during the global UI unification merge. It removes a duplicated `<button` tag that prevented the Vite dev server from starting.