### PR TITLE
fix: resolve schemaOpen reference error in ChatPage

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -19,6 +19,7 @@ export function ChatPage() {
   const [loading, setLoading] = useState(false);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
+  const [schemaOpen, setSchemaOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const skipNextFetch = useRef(false);
 


### PR DESCRIPTION
This PR resolves a `ReferenceError` in `ChatPage.tsx` where `schemaOpen` was used without being defined after a merge conflict. It restores the `useState` hook for toggling the Schema Explorer.