### PR TITLE
[codex] Fix frontend typing and connection modal flow

### DIFF
--- a/frontend/src/components/charts/modules/BarChartModule.tsx
+++ b/frontend/src/components/charts/modules/BarChartModule.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { Info } from 'lucide-react';
 import type { ChartModuleProps } from '../types';
@@ -325,4 +325,3 @@ export function BarChartModule({
     </>
   );
 }
-

--- a/frontend/src/components/charts/shared/CustomTooltip.tsx
+++ b/frontend/src/components/charts/shared/CustomTooltip.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { formatColLabel } from '../utils/dataProcessors';
+import { T } from '../../dashboard/tokens';
 
 function formatLabel(raw: string): string {
   if (typeof raw !== 'string') return String(raw);
@@ -25,8 +25,6 @@ export interface CustomTooltipProps {
   tooltipColumns?: string[];
 }
 
-import { T } from '../../dashboard/tokens';
-
 export function CustomTooltip({ active, payload, label, normalizedColMaxes, categoryCol, tooltipColumns }: CustomTooltipProps) {
   if (!active || !payload?.length) return null;
   const tt = {
@@ -47,7 +45,7 @@ export function CustomTooltip({ active, payload, label, normalizedColMaxes, cate
   return (
     <div style={tt}>
       <div style={{ fontWeight: 600, marginBottom: 6, color: T.text2 }}>{formatLabel(String(label ?? ''))}</div>
-      {categoryCol && rowData[categoryCol] && (
+      {categoryCol && rowData[categoryCol] != null && (
         <div style={{ color: primaryColor, marginBottom: 4, fontWeight: 500 }}>
           {categoryCol} : {String(rowData[categoryCol])}
         </div>

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import { T } from '../dashboard/tokens';
 import type { ChatInputProps } from '../../types/chat';
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -6,8 +6,7 @@ import { BaseChartContainer } from '../charts/BaseChartContainer';
 import { AddToDashboardModal } from './AddToDashboardModal';
 import { SaveQueryModal } from './SaveQueryModal';
 import { useSmartSave } from '../../hooks/useSmartSave';
-import { inferViz, autoTitle, layoutDims } from '../../utils/dashboardUtils';
-import { Pin, Save, Plus, RotateCcw, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Pin, Plus, RotateCcw, ThumbsUp, ThumbsDown } from 'lucide-react';
 import type { ChatMessageView } from '../../types/chat';
 
 export function MessageBubble({ 

--- a/frontend/src/components/chat/ResultsPanel.tsx
+++ b/frontend/src/components/chat/ResultsPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ResultsTable } from './ResultsTable';
 import { BaseChartContainer } from '../charts/BaseChartContainer';
 import { T } from '../dashboard/tokens';

--- a/frontend/src/components/chat/SaveQueryModal.tsx
+++ b/frontend/src/components/chat/SaveQueryModal.tsx
@@ -223,7 +223,7 @@ export function SaveQueryModal({ isOpen, onClose, sql, defaultTitle, connectionI
                   { id: 'Uncategorized', label: 'Uncategorized' },
                   ...folders.filter(f => f.name !== 'Uncategorized' && f.name !== 'Public Library').map(f => ({ id: f.name, label: f.name })),
                   { id: '__new__', label: 'Create new folder...', isAction: true }
-                ].map((opt, i) => (
+                ].map((opt) => (
                   <div
                     key={opt.id}
                     onClick={() => handleFolderChange(opt.id)}

--- a/frontend/src/components/chat/Sidebar.tsx
+++ b/frontend/src/components/chat/Sidebar.tsx
@@ -1,14 +1,9 @@
 import { useState } from 'react';
 import { T } from '../dashboard/tokens';
-import { useSettingsStore } from '../../store/settingsStore';
 import type { ChatSidebarProps } from '../../types/chat';
 import { DeleteSessionModal } from './DeleteSessionModal';
 
 export function Sidebar({ sessions, activeSessionId, onSelectSession, onNewChat, onDeleteSession, onRenameSession, connections, activeConnectionId }: ChatSidebarProps) {
-  const { settings } = useSettingsStore();
-  const displayName = settings?.full_name || 'User';
-  const avatarInitials = displayName.substring(0, 2).toUpperCase();
-
   const [search, setSearch] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');

--- a/frontend/src/components/connections/ConnectionDetail.tsx
+++ b/frontend/src/components/connections/ConnectionDetail.tsx
@@ -3,30 +3,20 @@ import { T } from '../dashboard/tokens';
 import { StatusIndicator } from '../common/StatusIndicator';
 import { testConnection, updateConnectionSettings } from '../../services/api';
 import type { ConnectionDetailProps, ConnectionDetailTab, ConnectionListItem } from '../../types/connections';
+import type { QueryRecord, SchemaColumn, SchemaResponse, SchemaTable as ApiSchemaTable } from '../../types/api';
 import { ErdDiagram } from './ErdDiagram';
 
 // ---------------------------------------------------------------------------
 // Local type definitions for schema and query data
 // ---------------------------------------------------------------------------
-interface ColumnSchema {
+interface UiColumnSchema {
   name: string;
   type?: string;
-  primary_key?: boolean;
-  is_foreign_key?: boolean;
+  isPk?: boolean;
+  isFk?: boolean;
 }
 
-interface TableSchema {
-  name: string;
-  row_count?: number;
-  columns?: ColumnSchema[];
-}
-
-interface QueryRecord {
-  success: boolean;
-  sql: string;
-  execution_time_ms?: number;
-  timestamp: string;
-}
+type TableSchema = ApiSchemaTable;
 
 export function ConnectionDetail({ connection, schema, queryHistory, onDelete, onRefreshSchema }: ConnectionDetailProps) {
   const [activeTab, setActiveTab] = useState<ConnectionDetailTab>('overview');
@@ -93,7 +83,7 @@ export function ConnectionDetail({ connection, schema, queryHistory, onDelete, o
         
         {activeTab === 'overview' && <OverviewTab connection={connection} schema={schema} queryHistory={queryHistory} onTabSwitch={setActiveTab} />}
         {activeTab === 'credentials' && <CredentialsTab connection={connection} />}
-        {activeTab === 'schema' && <SchemaTab schema={schema} onRefresh={onRefreshSchema} />}
+        {activeTab === 'schema' && <SchemaTab schema={schema ?? undefined} onRefresh={onRefreshSchema} />}
         {activeTab === 'security' && <SecurityTab />}
         {activeTab === 'activity' && <ActivityTab queryHistory={queryHistory} />}
 
@@ -152,7 +142,7 @@ function Tab({ active, label, onClick }: { active: boolean, label: string, onCli
 // Tabs Content
 // ------------------------
 
-function OverviewTab({ connection, schema, queryHistory, onTabSwitch }: { connection: ConnectionListItem, schema?: ConnectionDetailProps['schema'], queryHistory?: ConnectionDetailProps['queryHistory'], onTabSwitch: (tab: ConnectionDetailTab) => void }) {
+function OverviewTab({ connection, schema, queryHistory, onTabSwitch }: { connection: ConnectionListItem, schema?: SchemaResponse | null, queryHistory?: QueryRecord[], onTabSwitch: (tab: ConnectionDetailTab) => void }) {
   const tables = schema?.tables || [];
   const tableCount = tables.length;
   const recentQueries = (queryHistory || []).slice(0, 3);
@@ -171,7 +161,12 @@ function OverviewTab({ connection, schema, queryHistory, onTabSwitch }: { connec
             {tables.slice(0, 4).map((t: TableSchema, i: number) => (
               <SchemaTable key={i} name={t.name} rows={t.row_count != null ? `${t.row_count.toLocaleString()} rows` : 'N/A'}
                 defaultExpanded={i === 0}
-                cols={t.columns?.map((c: ColumnSchema) => ({ name: c.name, type: c.type?.split('(')[0]?.toUpperCase() || 'UNK', isPk: c.primary_key, isFk: c.is_foreign_key })) || []} />
+                cols={t.columns?.map((c: SchemaColumn) => ({
+                  name: c.name,
+                  type: c.type?.split('(')[0]?.toUpperCase() || 'UNK',
+                  isPk: c.primary_key,
+                  isFk: t.foreign_keys.some((fk) => fk.column === c.name),
+                })) || []} />
             ))}
             {tables.length === 0 && <div style={{ color: T.text3, fontSize: '0.78rem', padding: 8 }}>No tables found</div>}
           </div>
@@ -336,7 +331,7 @@ function CredentialsTab({ connection }: { connection: ConnectionListItem }) {
   );
 }
 
-function SchemaTab({ schema, onRefresh }: { schema?: { tables?: TableSchema[] }, onRefresh?: () => void }) {
+function SchemaTab({ schema, onRefresh }: { schema?: SchemaResponse, onRefresh?: () => void }) {
   const tables = schema?.tables || [];
   const [viewMode, setViewMode] = useState<'table' | 'erd'>('table');
 
@@ -458,7 +453,7 @@ function SectionCard({ title, badge, onAction, actionText, children }: { title: 
   );
 }
 
-function SchemaTable({ name, rows, defaultExpanded, cols }: { name: string, rows: string, defaultExpanded?: boolean, cols: ColumnSchema[] }) {
+function SchemaTable({ name, rows, defaultExpanded, cols }: { name: string, rows: string, defaultExpanded?: boolean, cols: UiColumnSchema[] }) {
   const [isOpen, setIsOpen] = useState(defaultExpanded || false);
   return (
     <div style={{ marginBottom: 4 }}>
@@ -516,22 +511,6 @@ function FormGroup({ label, req, value, full, select }: { label: string, req?: b
       ) : (
         <input defaultValue={value} type={full && label === 'Password' ? 'password' : 'text'} style={{ background: T.s2, border: `1px solid ${T.border}`, borderRadius: 9, padding: '9px 13px', color: T.text, fontFamily: T.fontBody, fontSize: '0.83rem', outline: 'none', width: '100%' }} />
       )}
-    </div>
-  )
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ToggleRow({ label, sub, on }: { label: string, sub: string, on?: boolean }) {
-  const [isOn, setIsOn] = useState(on || false);
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', background: T.s2, border: `1px solid ${T.border}`, borderRadius: 9 }}>
-      <div>
-        <div style={{ fontSize: '0.8rem', color: T.text2 }}>{label}</div>
-        <div style={{ fontSize: '0.68rem', color: T.text3, marginTop: 1 }}>{sub}</div>
-      </div>
-      <div onClick={() => setIsOn(!isOn)} style={{ width: 36, height: 20, borderRadius: 20, cursor: 'pointer', position: 'relative', background: isOn ? T.accent : T.s4, flexShrink: 0, transition: 'background 0.2s' }}>
-        <div style={{ position: 'absolute', width: 14, height: 14, borderRadius: '50%', background: '#fff', top: 3, left: isOn ? 19 : 3, transition: 'left 0.2s' }} />
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/connections/NewConnectionModal.tsx
+++ b/frontend/src/components/connections/NewConnectionModal.tsx
@@ -1,13 +1,65 @@
 import { useState } from 'react';
 import { T } from '../dashboard/tokens';
-import { connectDatabase } from '../../services/api';
+import { connectDatabase, testConnection } from '../../services/api';
 
 export function NewConnectionModal({ isOpen, onClose, onSaved }: { isOpen: boolean, onClose: () => void, onSaved?: () => void }) {
   const [step, setStep] = useState(1);
   const [selectedConnector, setSelectedConnector] = useState<string | null>(null);
   const [formData, setFormData] = useState({ name: '', host: 'localhost', port: '', database: '', username: '', password: '', ssl_mode: 'disable', readonly: true });
   const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string; tables?: number | null } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // SSH state
+  const [sshEnabled, setSshEnabled] = useState(false);
+  const [sshAuth, setSshAuth] = useState<'password' | 'key'>('password');
+  const [sshData, setSshData] = useState({ ssh_host: '', ssh_port: '22', ssh_username: '', ssh_password: '', ssh_private_key: '' });
+
+  const connectorMap: Record<string, string> = { pg: 'postgresql', my: 'mysql', sqlite: 'sqlite', sql: 'mssql', snow: 'snowflake', bq: 'bigquery', rs: 'redshift', dbx: 'databricks', xls: 'excel', gs: 'gsheets', csv: 'csv', duck: 'duckdb' };
+
+  const buildPayload = () => ({
+    db_type: connectorMap[selectedConnector || ''] || selectedConnector || '',
+    host: formData.host || 'localhost',
+    port: parseInt(formData.port) || 5432,
+    database: formData.database,
+    username: formData.username,
+    password: formData.password,
+    name: formData.name || undefined,
+    ssl_mode: formData.ssl_mode,
+    readonly: formData.readonly,
+    use_ssh: sshEnabled,
+    ...(sshEnabled ? {
+      ssh_host: sshData.ssh_host,
+      ssh_port: parseInt(sshData.ssh_port) || 22,
+      ssh_username: sshData.ssh_username,
+      ssh_password: sshAuth === 'password' ? sshData.ssh_password : undefined,
+      ssh_private_key: sshAuth === 'key' ? sshData.ssh_private_key : undefined,
+    } : {}),
+  });
+
+  const handleTest = async () => {
+    setTesting(true); setTestResult(null);
+    try {
+      const res = await testConnection(buildPayload() as any);
+      setTestResult({ success: res.success, message: res.message, tables: res.tables_found });
+    } catch (e: any) {
+      setTestResult({ success: false, message: e.message || 'Test failed' });
+    } finally { setTesting(false); }
+  };
+
+  const handleSave = async () => {
+    setSaving(true); setError(null);
+    try {
+      await connectDatabase(buildPayload() as any);
+      onSaved?.();
+      setStep(1); setSelectedConnector(null);
+      setFormData({ name: '', host: 'localhost', port: '', database: '', username: '', password: '', ssl_mode: 'disable', readonly: true });
+      setSshEnabled(false); setSshData({ ssh_host: '', ssh_port: '22', ssh_username: '', ssh_password: '', ssh_private_key: '' });
+      setTestResult(null);
+    } catch (e: any) {
+      setError(e.message || 'Failed to connect');
+    } finally { setSaving(false); }
+  };
 
   if (!isOpen) return null;
 
@@ -103,11 +155,80 @@ export function NewConnectionModal({ isOpen, onClose, onSaved }: { isOpen: boole
                 </div>
               </div>
 
+              {/* SSH Tunnel Section */}
+              <div style={{ height: 1, background: T.border, margin: '18px 0' }} />
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: sshEnabled ? 14 : 0 }}>
+                <div>
+                  <div style={{ fontSize: '0.68rem', fontWeight: 600, letterSpacing: '1.2px', color: T.text3, fontFamily: T.fontMono, textTransform: 'uppercase' as const }}>SSH Tunnel</div>
+                  <div style={{ fontSize: '0.72rem', color: T.text3, marginTop: 2 }}>Route through a bastion / jump host</div>
+                </div>
+                <button type="button" onClick={() => setSshEnabled(p => !p)} style={{ width: 38, height: 20, borderRadius: 10, border: 'none', cursor: 'pointer', background: sshEnabled ? T.accent : T.s4, position: 'relative', transition: 'background 0.2s', flexShrink: 0 }}>
+                  <div style={{ position: 'absolute', top: 2, left: sshEnabled ? 20 : 2, width: 16, height: 16, borderRadius: '50%', background: '#fff', transition: 'left 0.2s' }} />
+                </button>
+              </div>
+              {sshEnabled && (
+                <div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 12, marginBottom: 12 }}>
+                    <ModalInput label="SSH Host" placeholder="bastion.example.com" value={sshData.ssh_host} onChange={v => setSshData(p => ({...p, ssh_host: v}))} />
+                    <ModalInput label="SSH Port" placeholder="22" value={sshData.ssh_port} onChange={v => setSshData(p => ({...p, ssh_port: v}))} />
+                  </div>
+                  <ModalInput label="SSH Username" placeholder="ubuntu" value={sshData.ssh_username} onChange={v => setSshData(p => ({...p, ssh_username: v}))} />
+                  <div style={{ display: 'flex', gap: 8, margin: '12px 0 10px' }}>
+                    {(['password', 'key'] as const).map(opt => (
+                      <button key={opt} type="button" onClick={() => setSshAuth(opt)} style={{ padding: '5px 14px', borderRadius: 7, border: `1px solid ${sshAuth === opt ? 'rgba(0,229,255,0.4)' : T.border}`, background: sshAuth === opt ? T.accentDim : T.s3, color: sshAuth === opt ? T.accent : T.text3, fontFamily: T.fontMono, fontSize: '0.72rem', fontWeight: 600, cursor: 'pointer', transition: 'all 0.15s', textTransform: 'uppercase' as const }}>
+                        {opt === 'password' ? 'Password' : 'Private Key'}
+                      </button>
+                    ))}
+                  </div>
+                  {sshAuth === 'password'
+                    ? <ModalInput label="SSH Password" placeholder="••••••••" value={sshData.ssh_password} onChange={v => setSshData(p => ({...p, ssh_password: v}))} password />
+                    : <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                        <label style={{ fontSize: '0.72rem', color: T.text2, fontWeight: 600, fontFamily: T.fontMono }}>Private Key (PEM)</label>
+                        <textarea value={sshData.ssh_private_key} onChange={e => setSshData(p => ({...p, ssh_private_key: e.target.value}))} placeholder="-----BEGIN RSA PRIVATE KEY-----" rows={4} style={{ background: T.s3, border: `1px solid ${T.border}`, borderRadius: 9, padding: '9px 13px', color: T.text, fontFamily: T.fontMono, fontSize: '0.76rem', outline: 'none', width: '100%', resize: 'none', transition: 'border-color 0.2s', boxSizing: 'border-box' as const }}
+                          onFocus={e => e.target.style.borderColor = 'rgba(0,229,255,0.3)'}
+                          onBlur={e => e.target.style.borderColor = T.border}
+                        />
+                      </div>
+                  }
+                </div>
+              )}
+
               {error && <div style={{ marginTop: 12, padding: '9px 14px', borderRadius: 8, background: T.redDim, color: T.red, fontSize: '0.78rem', border: `1px solid rgba(248,113,113,0.2)` }}>{error}</div>}
             </div>
           )}
           {step === 3 && (
-             <div style={{ color: T.text2, textAlign: 'center', padding: '40px 0' }}>Test & Save coming soon...</div>
+            <div>
+              {/* Summary */}
+              <div style={{ background: T.s3, border: `1px solid ${T.border}`, borderRadius: 10, padding: '14px 18px', marginBottom: 20, fontSize: '0.83rem', color: T.text2 }}>
+                <span style={{ color: T.text, fontWeight: 600 }}>{formData.name || formData.database}</span> &nbsp;·&nbsp; {connectorMap[selectedConnector || ''] || selectedConnector} &nbsp;·&nbsp; {formData.host}:{formData.port || 5432}
+                {sshEnabled && <span style={{ marginLeft: 10, color: T.accent, fontSize: '0.75rem', fontFamily: T.fontMono }}>SSH via {sshData.ssh_host}</span>}
+              </div>
+
+              {/* Test Connection */}
+              <button onClick={handleTest} disabled={testing} style={{ width: '100%', padding: '12px', borderRadius: 10, border: `1px solid ${T.border}`, background: T.s3, color: T.text, fontFamily: T.fontBody, fontSize: '0.85rem', fontWeight: 600, cursor: testing ? 'not-allowed' : 'pointer', marginBottom: 12, transition: 'all 0.15s' }}
+                onMouseEnter={e => { if (!testing) e.currentTarget.style.borderColor = 'rgba(0,229,255,0.3)'; }}
+                onMouseLeave={e => { e.currentTarget.style.borderColor = T.border; }}
+              >
+                {testing ? '⏳ Testing...' : '🔌 Test Connection'}
+              </button>
+
+              {/* Test Result Banner */}
+              {testResult && (
+                <div style={{ padding: '11px 16px', borderRadius: 9, marginBottom: 16, fontSize: '0.82rem', fontWeight: 500, background: testResult.success ? 'rgba(34,197,94,0.08)' : 'rgba(248,113,113,0.08)', border: `1px solid ${testResult.success ? 'rgba(34,197,94,0.25)' : 'rgba(248,113,113,0.25)'}`, color: testResult.success ? T.green : T.red }}>
+                  {testResult.success ? '✓' : '✕'} {testResult.message}
+                  {testResult.success && testResult.tables != null && <span style={{ marginLeft: 8, opacity: 0.7 }}>· {testResult.tables} tables found</span>}
+                </div>
+              )}
+
+              {/* Save */}
+              <button onClick={handleSave} disabled={saving} style={{ width: '100%', padding: '12px', borderRadius: 10, border: 'none', background: saving ? T.s4 : T.accent, color: '#000', fontFamily: T.fontBody, fontSize: '0.85rem', fontWeight: 700, cursor: saving ? 'not-allowed' : 'pointer', boxShadow: saving ? 'none' : '0 4px 16px rgba(0,229,255,0.25)', transition: 'all 0.15s' }}
+                onMouseEnter={e => { if (!saving) e.currentTarget.style.opacity = '0.9'; }}
+                onMouseLeave={e => { e.currentTarget.style.opacity = '1'; }}
+              >
+                {saving ? 'Connecting...' : '→ Save & Connect'}
+              </button>
+              {error && <div style={{ marginTop: 10, padding: '9px 14px', borderRadius: 8, background: 'rgba(248,113,113,0.08)', color: T.red, fontSize: '0.78rem', border: `1px solid rgba(248,113,113,0.2)` }}>{error}</div>}
+            </div>
           )}
 
         </div>
@@ -120,33 +241,8 @@ export function NewConnectionModal({ isOpen, onClose, onSaved }: { isOpen: boole
              <button onClick={() => setStep(step - 1)} style={{ padding: '10px 18px', borderRadius: 9, border: `1px solid ${T.border}`, background: 'transparent', color: T.text2, fontFamily: T.fontBody, fontSize: '0.83rem', cursor: 'pointer', transition: 'all 0.15s' }}>← Back</button>
           )}
 
-          <button onClick={async () => {
-            if (step < 2) { setStep(step + 1); return; }
-            // Step 2: submit
-            const connectorMap: Record<string, string> = { pg: 'postgresql', my: 'mysql', sqlite: 'sqlite', sql: 'mssql', snow: 'snowflake', bq: 'bigquery', rs: 'redshift', dbx: 'databricks', xls: 'excel', gs: 'gsheets', csv: 'csv', duck: 'duckdb' };
-            setSaving(true); setError(null);
-            try {
-              await connectDatabase({
-                db_type: connectorMap[selectedConnector || ''] || selectedConnector || '',
-                host: formData.host || 'localhost',
-                port: parseInt(formData.port) || 5432,
-                database: formData.database,
-                username: formData.username,
-                password: formData.password,
-                name: formData.name || undefined,
-                ssl_mode: formData.ssl_mode,
-                readonly: formData.readonly,
-              } as any);
-              onSaved?.();
-              // Reset form
-              setStep(1); setSelectedConnector(null); setFormData({ name: '', host: 'localhost', port: '', database: '', username: '', password: '', ssl_mode: 'disable', readonly: true });
-            } catch (err: any) {
-              setError(err.message || 'Failed to connect');
-            } finally {
-              setSaving(false);
-            }
-          }} disabled={!selectedConnector || saving} style={{ padding: '10px 20px', borderRadius: 9, border: `1px solid rgba(0,229,255,0.25)`, background: T.accentDim, color: T.accent, fontFamily: T.fontBody, fontSize: '0.83rem', fontWeight: 600, cursor: selectedConnector && !saving ? 'pointer' : 'not-allowed', opacity: selectedConnector && !saving ? 1 : 0.5 }}>
-            {saving ? 'Connecting...' : step === 2 ? 'Save Connection' : 'Continue →'}
+          <button onClick={() => { if (step < 3) { setStep(step + 1); setTestResult(null); } }} disabled={!selectedConnector || step === 3} style={{ padding: '10px 20px', borderRadius: 9, border: `1px solid rgba(0,229,255,0.25)`, background: step < 3 && selectedConnector ? T.accentDim : 'transparent', color: step < 3 && selectedConnector ? T.accent : T.text3, fontFamily: T.fontBody, fontSize: '0.83rem', fontWeight: 600, cursor: step < 3 && selectedConnector ? 'pointer' : 'not-allowed', opacity: selectedConnector && step < 3 ? 1 : 0.4, display: step === 3 ? 'none' : 'block' }}>
+            Continue →
           </button>
         </div>
 

--- a/frontend/src/components/dashboard/DashboardFilterBar.tsx
+++ b/frontend/src/components/dashboard/DashboardFilterBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { T } from './tokens';
 
 interface DashboardFilterBarProps {

--- a/frontend/src/components/dashboard/WidgetRenderer.tsx
+++ b/frontend/src/components/dashboard/WidgetRenderer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { 
   ArrowDownToLine, 
   Maximize2, 
@@ -8,8 +8,6 @@ import {
   TrendingDown,
   MoreHorizontal,
   ChevronDown,
-  Table as TableIcon,
-  ChevronRight
 } from 'lucide-react';
 import { refreshDashboardWidget, getWidgetInsight } from '../../services/api';
 import { T } from './tokens';
@@ -39,36 +37,6 @@ function IconClose() {
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
-    </svg>
-  );
-}
-
-function IconRefresh({ spinning }: { spinning?: boolean }) {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={spinning ? 'refresh-spin' : ''}>
-      <polyline points="23 4 23 10 17 10" />
-      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-    </svg>
-  );
-}
-
-function IconDownload() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-      <polyline points="7 10 12 15 17 10" />
-      <line x1="12" y1="15" x2="12" y2="3" />
-    </svg>
-  );
-}
-
-function IconResize() {
-  return (
-    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <polyline points="15 3 21 3 21 9" />
-      <polyline points="9 21 3 21 3 15" />
-      <line x1="21" y1="3" x2="14" y2="10" />
-      <line x1="3" y1="21" x2="10" y2="14" />
     </svg>
   );
 }
@@ -343,7 +311,7 @@ function TableViz({ columns, rows, compact }: { columns: string[]; rows: Array<R
                     padding: '12px 16px', borderBottom: `1px solid rgba(255,255,255,0.03)`,
                     color: colIndex === 1 ? T.text : T.text2, 
                     fontWeight: colIndex === 1 ? 600 : 400,
-                    fontFamily: colIndex === 1 ? T.fontSans : T.fontMono,
+                    fontFamily: colIndex === 1 ? T.fontBody : T.fontMono,
                     fontSize: '0.78rem',
                     maxWidth: 300,
                   }}>

--- a/frontend/src/components/dashboard/charts/DashboardPieChart.tsx
+++ b/frontend/src/components/dashboard/charts/DashboardPieChart.tsx
@@ -71,8 +71,8 @@ export function DashboardPieChart({ widget, size: _size }: { widget: DashboardWi
   const total = data.reduce((sum, d) => sum + d.value, 0) || 1;
 
   const chartHeight = 220;
-  const outerRadius = "80%";
-  const innerRadius = isDonut ? "50%" : 0;
+  const outerRadius = "88%";
+  const innerRadius = isDonut ? "62%" : 0;
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', padding: '16px 16px 8px', gap: 12, height: 270, boxSizing: 'border-box' }}>
@@ -86,8 +86,8 @@ export function DashboardPieChart({ widget, size: _size }: { widget: DashboardWi
               nameKey="name"
               cx="50%"
               cy="50%"
-              innerRadius="62%"
-              outerRadius="88%"
+              innerRadius={innerRadius}
+              outerRadius={outerRadius}
               paddingAngle={4}
               cornerRadius={6}
               strokeWidth={0}

--- a/frontend/src/components/library/QueryDetailPanel.tsx
+++ b/frontend/src/components/library/QueryDetailPanel.tsx
@@ -76,7 +76,7 @@ export function QueryDetailPanel({ query, onClose, onDelete, onRefresh, initialT
       }
       onRefresh?.();
     } catch (err: unknown) {
-      const errorResult = { success: false, error: err instanceof Error ? err.message : String(err) };
+      const errorResult = { success: false as const, error: err instanceof Error ? err.message : String(err) };
       setRunResult(errorResult);
       setActiveTab('info');
     } finally {

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
-import  { ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface ModalProps {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { User, Session } from '@supabase/supabase-js';
+import type { User, Session } from '@supabase/supabase-js';
 import { supabase } from '../lib/supabase';
 
 interface AuthContextType {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import { MainShell } from '../components/common/MainShell';
-import { HeaderIcons } from '../components/common/AppHeader';
 import { Sidebar as ChatSidebar } from '../components/chat/Sidebar';
 import { ChatInput } from '../components/chat/ChatInput';
 import { MessageBubble } from '../components/chat/MessageBubble';
@@ -42,8 +41,8 @@ export function ChatPage() {
         sql: message.sql || undefined,
         columns: message.columns || message.results?.columns || undefined,
         rows: message.rows || message.results?.rows || undefined,
-        row_count: message.row_count ?? message.results?.row_count,
-        execution_time_ms: message.execution_time_ms ?? message.results?.execution_time_ms,
+        row_count: message.row_count ?? message.results?.row_count ?? undefined,
+        execution_time_ms: message.execution_time_ms ?? message.results?.execution_time_ms ?? undefined,
         chart_recommendation: message.chart_recommendation || undefined,
         column_metadata: message.column_metadata || undefined,
         error: message.error || undefined,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -218,8 +218,8 @@ function DashboardRail({
                   <DashboardCreateForm
                     value={newDashName}
                     onChange={onNewDashNameChange}
-                    onCreate={handleCreateDash}
-                    onCancel={() => setShowCreateForm(false)}
+                    onCreate={onCreate}
+                    onCancel={onCancelCreate}
                     creating={creating}
                     compact
                     ctaLabel="Add"
@@ -877,26 +877,6 @@ export function DashboardPage() {
     await exportToPNG('dashboard-grid', `${activeDash.name.replace(/\s+/g, '_')}_Dashboard`);
   };
 
-  const handleShareClick = async () => {
-    if (!activeDash) return;
-    try {
-      let token = activeDash.share_token;
-      if (!activeDash.is_public || !token) {
-        const updated = await updateDashboard(activeDash.id, { is_public: true });
-        token = updated.share_token;
-        await reloadDashboards();
-      }
-      if (token) {
-        const url = `${window.location.origin}/s/${token}`;
-        await navigator.clipboard.writeText(url);
-        alert(`Public link area enabled and copied to clipboard!\n${url}`);
-      }
-    } catch (err) {
-      console.error('Failed to create share link:', err);
-      alert('Failed to create share link.');
-    }
-  };
-
   return (
     <MainShell
       title={activeDash?.name || 'Dashboards'}
@@ -909,7 +889,6 @@ export function DashboardPage() {
       headerActions={
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <button style={headerIconBtnStyle} title="Search"><HeaderIcons.Search /></button>
-          <button onClick={handleShareClick} style={headerActionBtnStyle} title="Share"><HeaderIcons.Share /> Share URL</button>
           <button onClick={handleExportPNG} style={headerActionBtnStyle} title="Export Report"><HeaderIcons.Download /> Export PNG</button>
           <button 
             onClick={() => setShowCreateForm(true)}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -477,7 +477,8 @@ function ApiKeysSection() {
 
 // ── Billing (Mocked) ──────────────────────────────────────
 
-import { getBillingInfo, UserSubscription } from '../services/api';
+import { getBillingInfo } from '../services/api';
+import type { UserSubscription } from '../services/api';
 
 function BillingSection() {
   const navigate = useNavigate();

--- a/frontend/src/pages/SharedDashboardPage.tsx
+++ b/frontend/src/pages/SharedDashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { Responsive, WidthProvider } from 'react-grid-layout/legacy';
 import 'react-grid-layout/css/styles.css';

--- a/frontend/src/pages/UpgradePage.tsx
+++ b/frontend/src/pages/UpgradePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { T } from '../components/dashboard/tokens';
 import { upgradePlan } from '../services/api';

--- a/frontend/src/store/settingsStore.ts
+++ b/frontend/src/store/settingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { getSettings, updateSettings, UserSettings } from '../services/api';
+import { getSettings, updateSettings } from '../services/api';
+import type { UserSettings } from '../services/api';
 
 interface SettingsState {
   settings: UserSettings | null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -50,6 +50,13 @@ export interface ConnectDatabaseRequest {
   password: string;
   ssl_mode?: string;
   readonly?: boolean;
+  // SSH Tunnel
+  use_ssh?: boolean;
+  ssh_host?: string;
+  ssh_port?: number;
+  ssh_username?: string;
+  ssh_password?: string;
+  ssh_private_key?: string;
 }
 
 export interface ConnectDatabaseResponse extends DatabaseConnection {
@@ -63,6 +70,14 @@ export interface TestConnectionRequest {
   database: string;
   username: string;
   password: string;
+  ssl_mode?: string;
+  // SSH Tunnel
+  use_ssh?: boolean;
+  ssh_host?: string;
+  ssh_port?: number;
+  ssh_username?: string;
+  ssh_password?: string;
+  ssh_private_key?: string;
 }
 
 export interface TestConnectionResponse {
@@ -111,10 +126,15 @@ export interface ChatMessageRecord {
   sql?: string | null;
   columns?: string[] | null;
   results?: { 
+    columns?: string[];
     rows?: Array<Record<string, unknown>>;
-    row_count?: number;
-    execution_time_ms?: number;
+    row_count?: number | null;
+    execution_time_ms?: number | null;
   } | null;
+  rows?: Array<Record<string, unknown>> | null;
+  row_count?: number | null;
+  execution_time_ms?: number | null;
+  column_metadata?: Record<string, string> | null;
   chart_recommendation?: ChartRecommendation | null;
   error?: string | null;
   is_pinned?: boolean;
@@ -159,6 +179,8 @@ export interface ChatResponse {
   column_metadata?: Record<string, string>;
   xLabel?: string;
   yLabel?: string;
+  is_pinned?: boolean;
+  prev_query_id?: string | null;
 }
 
 export interface ChatUiMessage {
@@ -317,9 +339,12 @@ export interface CreateDashboardRequest {
 
 export interface DashboardSummary {
   id: string;
+  owner_id?: string;
   name: string;
   icon: string;
   filters: Record<string, any>;
+  is_public?: boolean;
+  share_token?: string | null;
   created_at: string;
   widget_count: number;
 }
@@ -328,6 +353,7 @@ export interface UpdateDashboardRequest {
   name?: string;
   icon?: string;
   filters?: Record<string, any>;
+  is_public?: boolean;
 }
 
 export interface DashboardChartConfig {


### PR DESCRIPTION
## What changed
- fixed frontend TypeScript and API typing mismatches across chat, dashboard, settings, and shared UI components
- aligned frontend API types with the current backend responses
- added connection-modal support for SSH tunnel fields and explicit test/save workflow
- removed a few dead imports and stale share-url UI logic that no longer matches the backend behavior

## Why
The frontend had accumulated build-breaking type drift and a partially implemented connection flow. This PR isolates the frontend repair work from the backend refactor so it can be reviewed and merged independently.

## User impact
- frontend builds successfully again
- connection setup supports SSH tunnel configuration and test-before-save flow
- dashboard/chat/settings screens are aligned with the current API responses

## Validation
- ran `npm run build` in `frontend/`
- build completed successfully
- Vite still reports chunk-size and dynamic-import warnings, but the build passes
