### PR TITLE
chore: update .gitignore with scratch and playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ frontend/build/
 # OS
 .DS_Store
 Thumbs.db
-.gemini/
 
 # Logs
 *.log
@@ -76,9 +75,16 @@ htmlcov/
 
 # Local mockups & metadata
 querymind-*.html
+# Local/Temporary/Scratch
+scratch/
+.gemini/
 .claude/
 .mcp.json
 .playwright-mcp/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
 
 # Assets & media (typically not committed if generated or large)
 # *.png (Commented out to allow professional showcase images)


### PR DESCRIPTION
### Chore: Update .gitignore

This PR updates the workspace configuration to ensure local temporary files and specific MCP server artifacts are not committed to the repository.

#### Changes:
- Added `scratch/` directory to the ignore list.
- Added Playwright reporting and cache artifacts (`test-results/`, `playwright-report/`, etc.).
- Consolidated `.gemini/`, `.claude/`, and `.mcp.json` into a dedicated "Local/Temporary" section.
- Removed redundant/duplicate entries.
