### PR TITLE
[codex] Clean up settings and connection diagnostics UI

### DIFF
--- a/frontend/src/components/connections/ConnectionDetail.tsx
+++ b/frontend/src/components/connections/ConnectionDetail.tsx
@@ -208,6 +208,7 @@ function CredentialsTab({ connection }: { connection: ConnectionListItem }) {
   const [testResult, setTestResult] = useState<{ success: boolean; message: string; tables_found?: number | null } | null>(null);
   const [sslMode, setSslMode] = useState(connection.ssl_mode ?? 'disable');
   const [readonly, setReadonly] = useState(connection.readonly ?? true);
+  const [password, setPassword] = useState('');
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
 
@@ -226,6 +227,14 @@ function CredentialsTab({ connection }: { connection: ConnectionListItem }) {
   };
 
   const runTest = async () => {
+    if (!password.trim()) {
+      setTestResult({
+        success: false,
+        message: 'Re-enter the database password to validate the saved connection credentials.',
+      });
+      return;
+    }
+
     setTesting(true);
     setTestResult(null);
     try {
@@ -235,7 +244,7 @@ function CredentialsTab({ connection }: { connection: ConnectionListItem }) {
         port: connection.port || 5432,
         database: connection.database || '',
         username: connection.username || '',
-        password: undefined,
+        password,
       });
       setTestResult(result);
     } catch (err: unknown) {
@@ -273,6 +282,32 @@ function CredentialsTab({ connection }: { connection: ConnectionListItem }) {
             </button>
             <span style={{ fontSize: '0.72rem', color: readonly ? T.text : T.text3, fontFamily: T.fontMono, fontWeight: 700 }}>{readonly ? 'READ-ONLY' : 'READ / WRITE'}</span>
           </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
+        <label style={{ fontSize: '0.62rem', color: T.text3, fontWeight: 700, fontFamily: T.fontMono, textTransform: 'uppercase', letterSpacing: '1px' }}>RE-ENTER PASSWORD FOR TEST</label>
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          placeholder="••••••••"
+          style={{
+            background: T.s2,
+            border: `1px solid ${T.border}`,
+            borderRadius: 0,
+            padding: '12px 16px',
+            color: T.text,
+            fontFamily: T.fontMono,
+            fontSize: '0.72rem',
+            outline: 'none',
+            width: '100%',
+            transition: 'all 0.15s',
+            letterSpacing: '0.5px'
+          }}
+        />
+        <div style={{ fontSize: '0.62rem', color: T.text3, fontFamily: T.fontMono, lineHeight: 1.6 }}>
+          This is used only for validation. It is not saved from this screen.
         </div>
       </div>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { 
-  User, Shield, Zap, Bell, Key, CreditCard, 
+  User, Zap, CreditCard, 
   LogOut, AlertTriangle,
   Monitor, Smartphone, ChevronRight
 } from 'lucide-react';
@@ -10,14 +10,10 @@ import { T } from '../components/dashboard/tokens';
 import { useSettingsStore } from '../store/settingsStore';
 import { useAuth } from '../context/AuthContext';
 
-type Section = 'profile' | 'security' | 'ai' | 'notifications' | 'apikeys' | 'billing';
+type Section = 'profile' | 'billing';
 
 const NAV: { id: Section; label: string; icon: any; badge?: string }[] = [
   { id: 'profile',       label: 'PROFILE',       icon: User },
-  { id: 'security',      label: 'SECURITY',      icon: Shield },
-  { id: 'ai',            label: 'AI ENGINE',     icon: Zap },
-  { id: 'notifications', label: 'ALERTS',        icon: Bell },
-  { id: 'apikeys',       label: 'API KEYS',      icon: Key },
   { id: 'billing',       label: 'BILLING',       icon: CreditCard, badge: 'PRO' },
 ];
 
@@ -103,10 +99,6 @@ export function SettingsPage() {
         <main style={{ flex: 1, overflowY: 'auto', padding: '64px 80px', position: 'relative', zIndex: 1 }} className="settings-scroll">
           <div style={{ maxWidth: 900, animation: 'fadeInScale 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) forwards' }}>
             {section === 'profile'       && <ProfileSection />}
-            {section === 'security'      && <SecuritySection />}
-            {section === 'ai'            && <AISection />}
-            {section === 'notifications' && <NotificationsSection />}
-            {section === 'apikeys'       && <ApiKeysSection />}
             {section === 'billing'       && <BillingSection />}
           </div>
         </main>
@@ -356,7 +348,7 @@ function ProfileSection() {
 }
 // ── Security (Mocked) ──────────────────────────────────────
 
-function SecuritySection() {
+export function SecuritySection() {
   const [twoFa, setTwoFa] = useState(false);
   const [sessions] = useState([
     { device: 'CHROME_ON_WINDOWS', location: 'KARACHI, PK', last: 'ACTIVE_NOW', current: true, icon: Monitor },
@@ -398,7 +390,7 @@ function SecuritySection() {
 
 // ── AI Engine & Queries ───────────────────────────────────
 
-function AISection() {
+export function AISection() {
   const { settings, updateSetting } = useSettingsStore();
   const [prompt, setPrompt] = useState(settings?.system_prompt || '');
   const [saving, setSaving] = useState(false);
@@ -474,7 +466,7 @@ function AISection() {
 
 // ── Notifications (Alerts) ────────────────────────────────
 
-function NotificationsSection() {
+export function NotificationsSection() {
   const { settings, updateSetting } = useSettingsStore();
   const [webhook, setWebhook] = useState(settings?.slack_webhook || '');
   const [channel, setChannel] = useState(settings?.slack_channel || '');
@@ -530,7 +522,7 @@ function NotificationsSection() {
 
 // ── API Access ────────────────────────────────────────────
 
-function ApiKeysSection() {
+export function ApiKeysSection() {
   const [keys] = useState([
     { name: 'PRODUCTION_DASHBOARD', prefix: 'QM_LIVE_4XK9', created: 'JAN_12_2026', last: '2_HOURS_AGO', scopes: ['READ', 'EXECUTE'] },
   ]);

--- a/frontend/src/pages/UpgradePage.tsx
+++ b/frontend/src/pages/UpgradePage.tsx
@@ -3,10 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { T } from '../components/dashboard/tokens';
 import { upgradePlan } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../components/common/ToastProvider';
 
 export function UpgradePage() {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { addToast } = useToast();
   const [loading, setLoading] = useState(false);
 
   const handleConfirmUpgrade = async () => {
@@ -29,9 +31,12 @@ export function UpgradePage() {
     try {
       console.warn("No VITE_LEMON_SQUEEZY_CHECKOUT_URL found. Simulating payment.");
       await upgradePlan();
+      addToast('Upgraded to Pro. Limits and counters reset.', 'success');
       navigate('/settings');
     } catch (err) {
       console.error(err);
+      const msg = err instanceof Error ? err.message : 'Upgrade failed. Please try again.';
+      addToast(msg, 'error');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- require re-entering the password when testing a saved database connection
- simplify settings navigation to the real product sections
- show success and error toast feedback in the local upgrade fallback flow

## Commits
- `Require password for saved connection diagnostics`
- `Simplify settings and surface upgrade feedback`

## Verification
- `npm run build`
