### PR TITLE
[codex] Move auth behind backend session flow

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.v1.routes import (
     analytics,
+    auth,
     chat,
     connections,
     dashboards,
@@ -15,6 +16,7 @@ from app.api.v1.routes import (
 
 api_router = APIRouter()
 
+api_router.include_router(auth.router)
 api_router.include_router(connections.router)
 api_router.include_router(query.router)
 api_router.include_router(chat.router)

--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+
+from app.api.deps import UncheckedUserDep
+from app.api.v1.schemas.auth import (
+    AuthCredentialsRequest,
+    AuthSessionResponse,
+    AuthUserResponse,
+)
+from app.api.v1.schemas.common import StatusMessageResponse
+from app.core.supabase_auth import (
+    ACCESS_TOKEN_COOKIE_NAME,
+    REFRESH_TOKEN_COOKIE_NAME,
+    clear_auth_cookies,
+    set_auth_cookies,
+)
+from app.services import auth as auth_service
+
+
+router = APIRouter(prefix="/api/auth", tags=["Auth"])
+
+
+def _session_response(result: auth_service.AuthSessionResult) -> AuthSessionResponse:
+    user = None
+    if result.user_id:
+        user = AuthUserResponse(id=result.user_id, email=result.email)
+    return AuthSessionResponse(
+        authenticated=result.authenticated,
+        user=user,
+        message=result.message,
+    )
+
+
+def _maybe_set_auth_cookies(response: Response, result: auth_service.AuthSessionResult) -> None:
+    if result.access_token and result.refresh_token:
+        set_auth_cookies(
+            response,
+            access_token=result.access_token,
+            refresh_token=result.refresh_token,
+            expires_in=result.expires_in,
+        )
+
+
+def _request_access_token(request: Request) -> str | None:
+    cookie_token = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)
+    if cookie_token:
+        return cookie_token
+
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+    return None
+
+
+@router.post("/signup", response_model=AuthSessionResponse)
+def signup(payload: AuthCredentialsRequest, response: Response):
+    try:
+        result = auth_service.signup(payload.email, payload.password)
+    except auth_service.AuthServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    _maybe_set_auth_cookies(response, result)
+    return _session_response(result)
+
+
+@router.post("/login", response_model=AuthSessionResponse)
+def login(payload: AuthCredentialsRequest, response: Response):
+    try:
+        result = auth_service.login(payload.email, payload.password)
+    except auth_service.AuthServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    _maybe_set_auth_cookies(response, result)
+    return _session_response(result)
+
+
+@router.post("/refresh", response_model=AuthSessionResponse)
+def refresh_session(request: Request, response: Response):
+    refresh_token = request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No refresh session is available.")
+
+    try:
+        result = auth_service.refresh_session(refresh_token)
+    except auth_service.AuthServiceError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.message) from exc
+
+    _maybe_set_auth_cookies(response, result)
+    return _session_response(result)
+
+
+@router.post("/logout", response_model=StatusMessageResponse)
+def logout(request: Request, response: Response):
+    auth_service.logout(_request_access_token(request))
+    clear_auth_cookies(response)
+    return {"message": "Signed out.", "status": "signed_out"}
+
+
+@router.get("/session", response_model=AuthSessionResponse)
+def get_session(current_user: UncheckedUserDep):
+    result = auth_service.build_active_session(current_user.id, current_user.email)
+    return _session_response(result)
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/schemas/auth.py
+++ b/backend/app/api/v1/schemas/auth.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AuthCredentialsRequest(BaseModel):
+    email: str
+    password: str
+
+
+class AuthUserResponse(BaseModel):
+    id: str
+    email: Optional[str] = None
+
+
+class AuthSessionResponse(BaseModel):
+    authenticated: bool
+    user: Optional[AuthUserResponse] = None
+    message: Optional[str] = None
+
+
+__all__ = [
+    "AuthCredentialsRequest",
+    "AuthUserResponse",
+    "AuthSessionResponse",
+]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     supabase_anon_key: str | None = None
     supabase_service_role_key: str | None = None
     supabase_jwt_secret: str | None = None
+    auth_cookie_secure: bool | None = None
+    auth_cookie_domain: str | None = None
+    auth_cookie_samesite: str = "lax"
 
     groq_api_key: str | None = None
     groq_model: str = "llama-3.3-70b-versatile"
@@ -74,6 +77,12 @@ class Settings(BaseSettings):
     def resolved_celery_broker_url(self) -> str | None:
         return self.celery_broker_url or self.redis_url
 
+    @property
+    def resolved_auth_cookie_secure(self) -> bool:
+        if self.auth_cookie_secure is None:
+            return self.is_production
+        return self.auth_cookie_secure
+
     def require(self, field_name: str) -> str:
         value = getattr(self, field_name)
         if not value:
@@ -100,6 +109,9 @@ class Settings(BaseSettings):
             "has_supabase_anon_key": bool(self.supabase_anon_key),
             "has_supabase_service_role_key": bool(self.supabase_service_role_key),
             "has_supabase_jwt_secret": bool(self.supabase_jwt_secret),
+            "auth_cookie_secure": self.resolved_auth_cookie_secure,
+            "auth_cookie_domain": bool(self.auth_cookie_domain),
+            "auth_cookie_samesite": self.auth_cookie_samesite,
             "has_groq_api_key": bool(self.groq_api_key),
             "groq_model": self.groq_model,
             "has_lemon_squeezy_webhook_secret": bool(self.lemon_squeezy_webhook_secret),

--- a/backend/app/core/secrets.py
+++ b/backend/app/core/secrets.py
@@ -28,7 +28,11 @@ def validate_core_credentials() -> None:
         "groq_api_key",
     ]
     if not settings.mock_auth_enabled:
-        required.append("supabase_jwt_secret")
+        required.extend([
+            "supabase_url",
+            "supabase_anon_key",
+            "supabase_jwt_secret",
+        ])
 
     missing = [name for name in required if not getattr(settings, name)]
     if missing:

--- a/backend/app/core/supabase_auth.py
+++ b/backend/app/core/supabase_auth.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from fastapi import Response
+
+from app.core.config import settings
+
+
+ACCESS_TOKEN_COOKIE_NAME = "qm_access_token"
+REFRESH_TOKEN_COOKIE_NAME = "qm_refresh_token"
+DEFAULT_ACCESS_TOKEN_MAX_AGE = 3600
+DEFAULT_REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 30
+
+
+def supabase_auth_base_url() -> str:
+    return settings.require("supabase_url").rstrip("/")
+
+
+def supabase_signup_url() -> str:
+    return f"{supabase_auth_base_url()}/auth/v1/signup"
+
+
+def supabase_password_login_url() -> str:
+    return f"{supabase_auth_base_url()}/auth/v1/token?grant_type=password"
+
+
+def supabase_refresh_url() -> str:
+    return f"{supabase_auth_base_url()}/auth/v1/token?grant_type=refresh_token"
+
+
+def supabase_logout_url() -> str:
+    return f"{supabase_auth_base_url()}/auth/v1/logout"
+
+
+def supabase_public_headers() -> dict[str, str]:
+    return {
+        "apikey": settings.require("supabase_anon_key"),
+        "Content-Type": "application/json",
+    }
+
+
+def supabase_auth_headers(access_token: str | None = None) -> dict[str, str]:
+    headers = supabase_public_headers()
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    return headers
+
+
+def auth_cookie_settings() -> dict[str, object]:
+    cookie_settings: dict[str, object] = {
+        "httponly": True,
+        "secure": settings.resolved_auth_cookie_secure,
+        "samesite": settings.auth_cookie_samesite.lower(),
+        "path": "/",
+    }
+    if settings.auth_cookie_domain:
+        cookie_settings["domain"] = settings.auth_cookie_domain
+    return cookie_settings
+
+
+def set_auth_cookies(
+    response: Response,
+    *,
+    access_token: str,
+    refresh_token: str,
+    expires_in: int | None = None,
+) -> None:
+    cookie_kwargs = auth_cookie_settings()
+    response.set_cookie(
+        ACCESS_TOKEN_COOKIE_NAME,
+        access_token,
+        max_age=expires_in or DEFAULT_ACCESS_TOKEN_MAX_AGE,
+        **cookie_kwargs,
+    )
+    response.set_cookie(
+        REFRESH_TOKEN_COOKIE_NAME,
+        refresh_token,
+        max_age=DEFAULT_REFRESH_TOKEN_MAX_AGE,
+        **cookie_kwargs,
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    cookie_kwargs = auth_cookie_settings()
+    response.delete_cookie(ACCESS_TOKEN_COOKIE_NAME, **cookie_kwargs)
+    response.delete_cookie(REFRESH_TOKEN_COOKIE_NAME, **cookie_kwargs)
+
+
+__all__ = [
+    "ACCESS_TOKEN_COOKIE_NAME",
+    "REFRESH_TOKEN_COOKIE_NAME",
+    "DEFAULT_ACCESS_TOKEN_MAX_AGE",
+    "DEFAULT_REFRESH_TOKEN_MAX_AGE",
+    "supabase_signup_url",
+    "supabase_password_login_url",
+    "supabase_refresh_url",
+    "supabase_logout_url",
+    "supabase_public_headers",
+    "supabase_auth_headers",
+    "auth_cookie_settings",
+    "set_auth_cookies",
+    "clear_auth_cookies",
+]

--- a/backend/app/integrations/supabase_auth/dependencies.py
+++ b/backend/app/integrations/supabase_auth/dependencies.py
@@ -1,18 +1,20 @@
 import logging
 from typing import Optional
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
+from app.core.config import settings
 from app.core.errors import ServiceUnavailableError
+from app.core.supabase_auth import ACCESS_TOKEN_COOKIE_NAME
 from app.db.orm_models import UserSettingsORM
 from app.db.session import session_scope
 from app.integrations.supabase_auth.jwt import JWTError, decode_supabase_jwt, get_jwt_key
 
 
 logger = logging.getLogger(__name__)
-security = HTTPBearer(auto_error=True)
+security = HTTPBearer(auto_error=False)
 
 
 class User(BaseModel):
@@ -38,11 +40,38 @@ async def assert_user_exists(user_id: str) -> None:
         )
 
 
+def _mock_user() -> User:
+    return User(id=settings.dev_user_id, email=settings.dev_user_email)
+
+
+def _authorization_token(credentials: Optional[HTTPAuthorizationCredentials]) -> str | None:
+    if credentials and credentials.scheme.lower() == "bearer":
+        return credentials.credentials
+    return None
+
+
+def _request_token(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials],
+) -> str | None:
+    cookie_token = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)
+    if cookie_token:
+        return cookie_token
+    return _authorization_token(credentials)
+
+
 async def authenticate_credentials(
+    request: Request,
     credentials: Optional[HTTPAuthorizationCredentials],
     verify_existence: bool = True,
 ) -> User:
-    if not credentials:
+    token = _request_token(request, credentials)
+
+    if settings.mock_auth_enabled:
+        if token is None or token == "dev-token":
+            return _mock_user()
+
+    if not token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing authentication credentials",
@@ -50,7 +79,7 @@ async def authenticate_credentials(
 
     try:
         try:
-            payload = decode_supabase_jwt(credentials.credentials)
+            payload = decode_supabase_jwt(token)
         except ValueError as exc:
             raise ServiceUnavailableError("Authentication service is not configured correctly.") from exc
 
@@ -82,16 +111,17 @@ async def authenticate_credentials(
 
 
 async def get_current_user(
+    request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    verify_existence: bool = True,
 ) -> User:
-    return await authenticate_credentials(credentials, verify_existence=verify_existence)
+    return await authenticate_credentials(request, credentials, verify_existence=True)
 
 
 async def get_user_no_check(
+    request: Request,
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> User:
-    return await authenticate_credentials(credentials, verify_existence=False)
+    return await authenticate_credentials(request, credentials, verify_existence=False)
 
 
 __all__ = [

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from fastapi import HTTPException, status
+
+from app.core.errors import ServiceUnavailableError
+from app.core.supabase_auth import (
+    supabase_auth_headers,
+    supabase_logout_url,
+    supabase_password_login_url,
+    supabase_refresh_url,
+    supabase_signup_url,
+)
+from app.integrations.supabase_auth.jwt import JWTError, decode_supabase_jwt
+from app.services import billing_service
+
+
+@dataclass
+class AuthSessionResult:
+    authenticated: bool
+    user_id: str | None
+    email: str | None
+    access_token: str | None = None
+    refresh_token: str | None = None
+    expires_in: int | None = None
+    message: str | None = None
+
+
+class AuthServiceError(Exception):
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+def _extract_error_message(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("msg", "message", "error_description", "error"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return "Authentication request failed."
+
+
+def _request_supabase(url: str, payload: dict[str, Any], *, invalid_status_code: int) -> dict[str, Any]:
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=supabase_auth_headers(),
+            timeout=15.0,
+        )
+    except httpx.HTTPError as exc:
+        raise ServiceUnavailableError("Authentication service is temporarily unavailable.") from exc
+
+    data: dict[str, Any]
+    try:
+        parsed = response.json()
+        data = parsed if isinstance(parsed, dict) else {}
+    except ValueError:
+        data = {}
+
+    if response.is_success:
+        return data
+
+    if response.status_code in {400, 401, 422}:
+        raise AuthServiceError(_extract_error_message(data), status_code=invalid_status_code)
+
+    raise ServiceUnavailableError("Authentication service is temporarily unavailable.")
+
+
+def _user_details_from_payload(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    user = payload.get("user")
+    if isinstance(user, dict):
+        user_id = user.get("id") or user.get("sub")
+        email = user.get("email")
+        return str(user_id) if user_id else None, str(email) if email else None
+
+    access_token = payload.get("access_token")
+    if isinstance(access_token, str) and access_token:
+        try:
+            decoded = decode_supabase_jwt(access_token)
+        except (ValueError, JWTError):
+            return None, None
+        user_id = decoded.get("sub")
+        email = decoded.get("email")
+        return str(user_id) if user_id else None, str(email) if email else None
+
+    return None, None
+
+
+def ensure_onboarded(user_id: str) -> None:
+    success = billing_service.onboard_user(user_id)
+    if not success:
+        raise ServiceUnavailableError("Failed to initialize user session.")
+
+
+def signup(email: str, password: str) -> AuthSessionResult:
+    payload = _request_supabase(
+        supabase_signup_url(),
+        {"email": email, "password": password},
+        invalid_status_code=status.HTTP_400_BAD_REQUEST,
+    )
+    user_id, resolved_email = _user_details_from_payload(payload)
+    if user_id:
+        ensure_onboarded(user_id)
+
+    access_token = payload.get("access_token") if isinstance(payload.get("access_token"), str) else None
+    refresh_token = payload.get("refresh_token") if isinstance(payload.get("refresh_token"), str) else None
+    expires_in = payload.get("expires_in") if isinstance(payload.get("expires_in"), int) else None
+    authenticated = bool(access_token and refresh_token)
+    message = None if authenticated else "Check your email to complete sign up."
+    return AuthSessionResult(
+        authenticated=authenticated,
+        user_id=user_id,
+        email=resolved_email,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+        message=message,
+    )
+
+
+def login(email: str, password: str) -> AuthSessionResult:
+    payload = _request_supabase(
+        supabase_password_login_url(),
+        {"email": email, "password": password},
+        invalid_status_code=status.HTTP_401_UNAUTHORIZED,
+    )
+    user_id, resolved_email = _user_details_from_payload(payload)
+    if not user_id:
+        raise ServiceUnavailableError("Authentication service returned an incomplete session.")
+    ensure_onboarded(user_id)
+
+    access_token = payload.get("access_token") if isinstance(payload.get("access_token"), str) else None
+    refresh_token = payload.get("refresh_token") if isinstance(payload.get("refresh_token"), str) else None
+    expires_in = payload.get("expires_in") if isinstance(payload.get("expires_in"), int) else None
+    if not access_token or not refresh_token:
+        raise ServiceUnavailableError("Authentication service returned an incomplete session.")
+
+    return AuthSessionResult(
+        authenticated=True,
+        user_id=user_id,
+        email=resolved_email,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+    )
+
+
+def refresh_session(refresh_token: str) -> AuthSessionResult:
+    payload = _request_supabase(
+        supabase_refresh_url(),
+        {"refresh_token": refresh_token},
+        invalid_status_code=status.HTTP_401_UNAUTHORIZED,
+    )
+    user_id, resolved_email = _user_details_from_payload(payload)
+    if not user_id:
+        raise ServiceUnavailableError("Authentication service returned an incomplete session.")
+    ensure_onboarded(user_id)
+
+    access_token = payload.get("access_token") if isinstance(payload.get("access_token"), str) else None
+    next_refresh_token = payload.get("refresh_token") if isinstance(payload.get("refresh_token"), str) else None
+    expires_in = payload.get("expires_in") if isinstance(payload.get("expires_in"), int) else None
+    if not access_token or not next_refresh_token:
+        raise ServiceUnavailableError("Authentication service returned an incomplete session.")
+
+    return AuthSessionResult(
+        authenticated=True,
+        user_id=user_id,
+        email=resolved_email,
+        access_token=access_token,
+        refresh_token=next_refresh_token,
+        expires_in=expires_in,
+    )
+
+
+def logout(access_token: str | None) -> None:
+    if not access_token:
+        return
+
+    try:
+        httpx.post(
+            supabase_logout_url(),
+            headers=supabase_auth_headers(access_token),
+            timeout=15.0,
+        )
+    except httpx.HTTPError:
+        return
+
+
+def build_active_session(user_id: str, email: str | None) -> AuthSessionResult:
+    ensure_onboarded(user_id)
+    return AuthSessionResult(
+        authenticated=True,
+        user_id=user_id,
+        email=email,
+    )
+
+
+__all__ = [
+    "AuthServiceError",
+    "AuthSessionResult",
+    "build_active_session",
+    "ensure_onboarded",
+    "login",
+    "logout",
+    "refresh_session",
+    "signup",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ uvicorn[standard]==0.32.1
 python-dotenv==1.0.1
 pydantic>=2.11.9
 pydantic-settings==2.6.1
+httpx>=0.27,<1.0
 
 # Database Drivers
 sqlalchemy==2.0.36

--- a/backend/tests/test_auth_backend.py
+++ b/backend/tests/test_auth_backend.py
@@ -1,0 +1,196 @@
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.db.session as db_session
+from app.api.deps import CurrentUserDep
+from app.api.v1.routes import auth as auth_route
+from app.core.config import settings
+from app.core.errors import register_exception_handlers
+from app.core.supabase_auth import ACCESS_TOKEN_COOKIE_NAME, REFRESH_TOKEN_COOKIE_NAME
+from app.db.base import Base
+from app.db.repositories import settings_repository
+from app.integrations.supabase_auth import dependencies as auth_dependencies
+from app.services.auth import AuthSessionResult
+
+
+@pytest.fixture(autouse=True)
+def sqlite_app_db():
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
+    db_session._engine = engine
+    db_session._session_factory = SessionLocal
+    Base.metadata.create_all(engine)
+    try:
+        yield
+    finally:
+        Base.metadata.drop_all(engine)
+        db_session.reset_engine_for_tests()
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.include_router(auth_route.router)
+
+    @app.get("/protected")
+    def protected(current_user: CurrentUserDep):
+        return {"id": current_user.id, "email": current_user.email}
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_auth(monkeypatch):
+    monkeypatch.setattr(settings, "backend_dev_mode", False, raising=False)
+    monkeypatch.setattr(settings, "supabase_jwt_secret", "test-secret", raising=False)
+
+
+def test_login_sets_auth_cookies_and_returns_user(client, monkeypatch):
+    result = AuthSessionResult(
+        authenticated=True,
+        user_id="user-1",
+        email="user@example.com",
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_in=3600,
+    )
+    monkeypatch.setattr(auth_route.auth_service, "login", lambda email, password: result)
+
+    response = client.post("/api/auth/login", json={"email": "user@example.com", "password": "secret"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authenticated"] is True
+    assert body["user"]["id"] == "user-1"
+    set_cookie = "\n".join(response.headers.get_list("set-cookie"))
+    assert ACCESS_TOKEN_COOKIE_NAME in set_cookie
+    assert REFRESH_TOKEN_COOKIE_NAME in set_cookie
+
+
+def test_refresh_sets_rotated_auth_cookies(client, monkeypatch):
+    result = AuthSessionResult(
+        authenticated=True,
+        user_id="user-1",
+        email="user@example.com",
+        access_token="next-access",
+        refresh_token="next-refresh",
+        expires_in=3600,
+    )
+    monkeypatch.setattr(auth_route.auth_service, "refresh_session", lambda token: result)
+    client.cookies.set(REFRESH_TOKEN_COOKIE_NAME, "refresh-token")
+
+    response = client.post("/api/auth/refresh")
+
+    assert response.status_code == 200
+    set_cookie = "\n".join(response.headers.get_list("set-cookie"))
+    assert "next-access" in set_cookie
+    assert "next-refresh" in set_cookie
+
+
+def test_logout_clears_cookies(client, monkeypatch):
+    monkeypatch.setattr(auth_route.auth_service, "logout", lambda token: None)
+    client.cookies.set(ACCESS_TOKEN_COOKIE_NAME, "access-token")
+
+    response = client.post("/api/auth/logout")
+
+    assert response.status_code == 200
+    set_cookie = "\n".join(response.headers.get_list("set-cookie"))
+    assert f"{ACCESS_TOKEN_COOKIE_NAME}=" in set_cookie
+    assert f"{REFRESH_TOKEN_COOKIE_NAME}=" in set_cookie
+
+
+def test_session_bootstraps_user_rows_from_valid_cookie(client, monkeypatch):
+    user_id = str(uuid.uuid4())
+
+    def decode(_token: str):
+        return {"sub": user_id, "email": "new@example.com"}
+
+    monkeypatch.setattr(auth_dependencies, "decode_supabase_jwt", decode)
+    client.cookies.set(ACCESS_TOKEN_COOKIE_NAME, "valid-token")
+
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authenticated"] is True
+    assert body["user"]["id"] == user_id
+    user_settings = settings_repository.get_user_settings(user_id)
+    subscription = settings_repository.get_user_subscription(user_id)
+    assert user_settings.owner_id == user_id
+    assert subscription.owner_id == user_id
+
+
+def test_session_returns_401_without_auth(client):
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 401
+
+
+def test_protected_route_accepts_cookie_auth(client, monkeypatch):
+    user_id = str(uuid.uuid4())
+    settings_repository.onboard_user(user_id)
+
+    def decode(_token: str):
+        return {"sub": user_id, "email": "cookie@example.com"}
+
+    monkeypatch.setattr(auth_dependencies, "decode_supabase_jwt", decode)
+    client.cookies.set(ACCESS_TOKEN_COOKIE_NAME, "cookie-token")
+
+    response = client.get("/protected")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == user_id
+
+
+def test_protected_route_falls_back_to_authorization_header(client, monkeypatch):
+    user_id = str(uuid.uuid4())
+    settings_repository.onboard_user(user_id)
+
+    def decode(_token: str):
+        return {"sub": user_id, "email": "header@example.com"}
+
+    monkeypatch.setattr(auth_dependencies, "decode_supabase_jwt", decode)
+
+    response = client.get("/protected", headers={"Authorization": "Bearer header-token"})
+
+    assert response.status_code == 200
+    assert response.json()["email"] == "header@example.com"
+
+
+def test_invalid_token_returns_401(client, monkeypatch):
+    def decode(_token: str):
+        raise auth_dependencies.JWTError("bad token")
+
+    monkeypatch.setattr(auth_dependencies, "decode_supabase_jwt", decode)
+    client.cookies.set(ACCESS_TOKEN_COOKIE_NAME, "bad-token")
+
+    response = client.get("/protected")
+
+    assert response.status_code == 401
+
+
+def test_mock_auth_bypass_still_works(client, monkeypatch):
+    monkeypatch.setattr(settings, "backend_dev_mode", True, raising=False)
+    monkeypatch.setattr(settings, "supabase_jwt_secret", None, raising=False)
+
+    response = client.get("/protected")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == settings.dev_user_id

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.101.1",
         "@tailwindcss/vite": "^4.1.18",
         "@types/react-grid-layout": "^1.3.6",
         "axios": "^1.13.2",
@@ -1290,92 +1289,6 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.101.1.tgz",
-      "integrity": "sha512-Kd0Wey+RkFHgyVep7adS6UOE2pN6MJ3mZ32PAXSvfw6IjUkFRC7IQpdZZjUOcUe5pXr1ejufCRgF6lsGINe4Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.101.1.tgz",
-      "integrity": "sha512-OZWU7YtaG+NNNFZK8p/FuJ6gpq7pFyrG2fLOopP73HAIDHDGpOttPJapvO8ADu3RkqfQfkwrB354vPkSBbZ20A==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/phoenix": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
-      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
-      "license": "MIT"
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.101.1.tgz",
-      "integrity": "sha512-UW1RajH5jbZoK+ldAJ1I6VZ+HWwZ2oaKjEQ6Gn+AQ67CHQVxGl8wNQoLYyumbyaExm41I+wn7arulcY1eHeZJw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.101.1.tgz",
-      "integrity": "sha512-Oa6dno0OB9I+hv5do5zsZHbFu41ViZnE9IWjmkeeF/8fPmB5fWoHGqeTYEC3/0DAgtpUoFJa4FpvzFH0SBHo1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/phoenix": "^0.4.0",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.101.1.tgz",
-      "integrity": "sha512-WhTaUOBgeEvnKLy95Cdlp6+D5igSF/65yC727w1olxbet5nzUvMlajKUWyzNtQu2efrz2cQ7FcdVBdQqgT9YKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "iceberg-js": "^0.8.1",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.101.1.tgz",
-      "integrity": "sha512-Jnhm3LfuACwjIzvk2pfUbGQn7pa7hi6MFzfSyPrRYWVCCu69RPLCFyHSBl7HSBwadbQ3UZOznnD3gPca3ePrRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.101.1",
-        "@supabase/functions-js": "2.101.1",
-        "@supabase/postgrest-js": "2.101.1",
-        "@supabase/realtime-js": "2.101.1",
-        "@supabase/storage-js": "2.101.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@swc/core": {
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.7.tgz",
@@ -1939,6 +1852,7 @@
       "version": "24.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1977,15 +1891,6 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.50.0",
@@ -3447,15 +3352,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/iceberg-js": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
-      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4678,6 +4574,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4859,27 +4756,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.101.1",
     "@tailwindcss/vite": "^4.1.18",
     "@types/react-grid-layout": "^1.3.6",
     "axios": "^1.13.2",

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,42 +1,49 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import type { User, Session } from '@supabase/supabase-js';
-import { supabase } from '../lib/supabase';
+import {
+  getAuthSession,
+  signIn as signInRequest,
+  signOut as signOutRequest,
+  signUp as signUpRequest,
+} from '../services/auth';
+import type { AuthSessionResponse, AuthUserResponse } from '../types/api';
 
 interface AuthContextType {
-  user: User | null;
-  session: Session | null;
+  user: AuthUserResponse | null;
   loading: boolean;
+  signIn: (email: string, password: string) => Promise<AuthSessionResponse>;
+  signUp: (email: string, password: string) => Promise<AuthSessionResponse>;
   signOut: () => Promise<void>;
-  onboardUser: () => Promise<void>;
+  refreshSession: () => Promise<AuthSessionResponse | null>;
   isDevMode: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-// Developer Bypass Configuration
 const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true';
-const MOCK_USER: User = {
+const MOCK_USER: AuthUserResponse = {
   id: '00000000-0000-0000-0000-000000000000',
   email: 'dev@query-mind.com',
-  role: 'authenticated',
-  aud: 'authenticated',
-  created_at: new Date().toISOString(),
-  app_metadata: {},
-  user_metadata: { full_name: 'Dev Guest' },
-} as any;
-
-const MOCK_SESSION: Session = {
-  access_token: 'dev-token',
-  token_type: 'bearer',
-  expires_in: 3600,
-  refresh_token: 'dev-refresh',
-  user: MOCK_USER,
 };
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(DEV_MODE ? MOCK_USER : null);
-  const [session, setSession] = useState<Session | null>(DEV_MODE ? MOCK_SESSION : null);
+  const [user, setUser] = useState<AuthUserResponse | null>(DEV_MODE ? MOCK_USER : null);
   const [loading, setLoading] = useState(!DEV_MODE);
+
+  const refreshSession = async (): Promise<AuthSessionResponse | null> => {
+    if (DEV_MODE) {
+      setUser(MOCK_USER);
+      return { authenticated: true, user: MOCK_USER };
+    }
+
+    try {
+      const session = await getAuthSession();
+      setUser(session.authenticated ? session.user : null);
+      return session;
+    } catch {
+      setUser(null);
+      return null;
+    }
+  };
 
   useEffect(() => {
     if (DEV_MODE) {
@@ -44,53 +51,36 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       return;
     }
 
-    // Get initial session
-    supabase.auth.getSession().then(async ({ data: { session } }) => {
-      setSession(session);
-      setUser(session?.user ?? null);
-      if (session?.user && !DEV_MODE) {
-        // Silently ensure onboarding on every load
-        try {
-          const { request } = await import('../services/http');
-          await request('/settings/onboard', { method: 'POST' });
-        } catch (e) {
-          console.warn("Onboarding check failed", e);
-        }
-      }
-      setLoading(false);
-    });
-
-    // Listen for auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_event, session) => {
-      setSession(session);
-      setUser(session?.user ?? null);
-      setLoading(false);
-    });
-
-    return () => subscription.unsubscribe();
+    void refreshSession().finally(() => setLoading(false));
   }, []);
+
+  const signIn = async (email: string, password: string) => {
+    const session = await signInRequest({ email, password });
+    setUser(session.authenticated ? session.user : null);
+    return session;
+  };
+
+  const signUp = async (email: string, password: string) => {
+    const session = await signUpRequest({ email, password });
+    setUser(session.authenticated ? session.user : null);
+    return session;
+  };
 
   const signOut = async () => {
     if (DEV_MODE) {
-      console.warn('Sign out is disabled in DEV_MODE');
+      setUser(MOCK_USER);
       return;
     }
-    await supabase.auth.signOut();
-  };
 
-  const onboardUser = async () => {
-    if (DEV_MODE) return;
-    const { request } = await import('../services/http');
     try {
-      await request('/settings/onboard', { method: 'POST' });
-    } catch (err) {
-      console.error('Failed to onboard user:', err);
-      throw err;
+      await signOutRequest();
+    } finally {
+      setUser(null);
     }
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, loading, signOut, onboardUser, isDevMode: DEV_MODE }}>
+    <AuthContext.Provider value={{ user, loading, signIn, signUp, signOut, refreshSession, isDevMode: DEV_MODE }}>
       {!loading && children}
     </AuthContext.Provider>
   );
@@ -103,3 +93,4 @@ export const useAuth = () => {
   }
   return context;
 };
+

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '../lib/supabase';
 import { T } from '../components/dashboard/tokens';
 import { useAuth } from '../context/AuthContext';
 import { Mail, ChevronRight, Activity, Globe, LockKeyhole } from 'lucide-react';
@@ -8,7 +7,7 @@ import { LandingOverlay } from '../components/landing/LandingOverlay';
 
 export function AuthPage() {
   const navigate = useNavigate();
-  const { user, isDevMode, onboardUser } = useAuth();
+  const { user, isDevMode, signIn, signUp } = useAuth();
   const [isLogin, setIsLogin] = useState(true);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -17,25 +16,10 @@ export function AuthPage() {
   const [auditLogs, setAuditLogs] = useState<string[]>([]);
 
   useEffect(() => {
-    const freshCheck = async () => {
-      if (user || isDevMode) {
-        if (!isDevMode) {
-          try {
-            await onboardUser();
-            const { request } = await import('../services/http');
-            await request('/settings/me'); 
-          } catch (err) {
-            console.warn("Auth verification/onboarding failed, but proceeding to dashboard:", err);
-          }
-          navigate('/dashboard');
-        } else {
-          navigate('/dashboard');
-        }
-      }
-    };
-    freshCheck();
-    
-    // Mock audit logs for the visual side
+    if (user || isDevMode) {
+      navigate('/dashboard');
+    }
+
     const logs = [
       'SECURE_GATEWAY_INITIALIZED',
       'LISTENING_ON_PORT_443',
@@ -45,41 +29,29 @@ export function AuthPage() {
     ];
     let i = 0;
     const iv = setInterval(() => {
-      if (i < logs.length) setAuditLogs(prev => [...prev, logs[i++]]);
+      if (i < logs.length) {
+        setAuditLogs(prev => [...prev, logs[i++]]);
+      }
     }, 1000);
     return () => clearInterval(iv);
   }, [user, isDevMode, navigate]);
-
-  const handleOAuthLogin = async (provider: 'google') => {
-    try {
-      setLoading(true);
-      setError(null);
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider,
-        options: { redirectTo: window.location.origin + '/dashboard' }
-      });
-      if (error) throw error;
-    } catch (err: any) {
-      setError(err.message || 'Failed to authenticate');
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleEmailAuth = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       setLoading(true);
       setError(null);
-      
-      if (isLogin) {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
-      } else {
-        const { data, error } = await supabase.auth.signUp({ email, password });
-        if (error) throw error;
-        if (!data.session) setError("SUCCESS // CHECK_EMAIL_FOR_LINK");
+
+      const session = isLogin
+        ? await signIn(email, password)
+        : await signUp(email, password);
+
+      if (session.authenticated) {
+        navigate('/dashboard');
+        return;
       }
+
+      setError((session.message || 'Check your email to complete sign up.').toUpperCase());
     } catch (err: any) {
       setError(err.message?.toUpperCase() || 'AUTHENTICATION_FAILURE');
     } finally {
@@ -90,45 +62,53 @@ export function AuthPage() {
   return (
     <div style={{ minHeight: '100vh', display: 'flex', background: T.bg, position: 'relative', overflow: 'hidden' }}>
       <LandingOverlay />
-      
-      {/* Left side: Cyber-Industrial Visual */}
-      <div style={{ 
-        flex: 1, position: 'relative', overflow: 'hidden', background: T.text,
-        display: 'flex', flexDirection: 'column', padding: 60, color: T.bg
-      }} className="auth-visual">
-        {/* Background Grid */}
-        <div style={{ 
-          position: 'absolute', inset: 0, 
-          backgroundImage: `linear-gradient(${T.accent}11 1px, transparent 1px), linear-gradient(90deg, ${T.accent}11 1px, transparent 1px)`, 
-          backgroundSize: '40px 40px', opacity: 0.3 
-        }} />
-        
+
+      <div
+        style={{
+          flex: 1, position: 'relative', overflow: 'hidden', background: T.text,
+          display: 'flex', flexDirection: 'column', padding: 60, color: T.bg
+        }}
+        className="auth-visual"
+      >
+        <div
+          style={{
+            position: 'absolute', inset: 0,
+            backgroundImage: `linear-gradient(${T.accent}11 1px, transparent 1px), linear-gradient(90deg, ${T.accent}11 1px, transparent 1px)`,
+            backgroundSize: '40px 40px', opacity: 0.3
+          }}
+        />
+
         <div style={{ position: 'relative', zIndex: 1 }}>
-          <div style={{ 
-            display: 'inline-flex', alignItems: 'center', gap: 12, 
-            background: 'rgba(0,0,0,0.3)', border: `1px solid ${T.accent}33`, 
-            padding: '8px 16px', fontFamily: T.fontMono, fontSize: '0.55rem', 
-            letterSpacing: 2, fontWeight: 950, marginBottom: 40
-          }}>
+          <div
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: 12,
+              background: 'rgba(0,0,0,0.3)', border: `1px solid ${T.accent}33`,
+              padding: '8px 16px', fontFamily: T.fontMono, fontSize: '0.55rem',
+              letterSpacing: 2, fontWeight: 950, marginBottom: 40
+            }}
+          >
             <Activity size={10} color={T.accent} />
             SECURITY_AUDIT_PROTOCOL
           </div>
-          
-          <h2 style={{ 
-            fontFamily: T.fontHead, fontWeight: 950, fontSize: '4.5rem', 
-            letterSpacing: -3, lineHeight: 0.9, textTransform: 'uppercase', fontStyle: 'italic'
-          }}>
+
+          <h2
+            style={{
+              fontFamily: T.fontHead, fontWeight: 950, fontSize: '4.5rem',
+              letterSpacing: -3, lineHeight: 0.9, textTransform: 'uppercase', fontStyle: 'italic'
+            }}
+          >
             PROTECTING_YOUR_<br />
             <span style={{ color: T.accent }}>INTELLIGENCE.</span>
           </h2>
         </div>
 
-        {/* Audit Logs */}
         <div style={{ marginTop: 'auto', position: 'relative', zIndex: 1 }}>
-          <div style={{ 
-            fontFamily: T.fontMono, fontSize: '0.6rem', color: T.accent, 
-            display: 'flex', flexDirection: 'column', gap: 8 
-          }}>
+          <div
+            style={{
+              fontFamily: T.fontMono, fontSize: '0.6rem', color: T.accent,
+              display: 'flex', flexDirection: 'column', gap: 8
+            }}
+          >
             {auditLogs.map((log, i) => (
               <div key={i} style={{ display: 'flex', gap: 12, opacity: 0.7 + (i * 0.05) }}>
                 <span style={{ color: T.accent }}>[{new Date().toLocaleTimeString()}]</span>
@@ -139,23 +119,29 @@ export function AuthPage() {
         </div>
       </div>
 
-      {/* Right side: Clean Form */}
-      <div style={{ 
-        width: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', 
-        padding: 40, borderLeft: `1px solid ${T.border}`, background: T.bg, zIndex: 1 
-      }} className="auth-form-container">
+      <div
+        style={{
+          width: 600, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          padding: 40, borderLeft: `1px solid ${T.border}`, background: T.bg, zIndex: 1
+        }}
+        className="auth-form-container"
+      >
         <div style={{ width: '100%', maxWidth: 400 }}>
           <div style={{ marginBottom: 48 }}>
-            <div style={{ 
-              width: 40, height: 40, background: T.text, display: 'flex', 
-              alignItems: 'center', justifyContent: 'center', color: '#fff', 
-              fontFamily: T.fontHead, fontWeight: 950, fontSize: '1.4rem', 
-              marginBottom: 32, boxShadow: `6px 6px 0px ${T.accent}`
-            }}>Q</div>
-            <h1 style={{ 
-              fontFamily: T.fontHead, fontWeight: 950, fontSize: '2.5rem', 
-              letterSpacing: -1, textTransform: 'uppercase', marginBottom: 12 
-            }}>
+            <div
+              style={{
+                width: 40, height: 40, background: T.text, display: 'flex',
+                alignItems: 'center', justifyContent: 'center', color: '#fff',
+                fontFamily: T.fontHead, fontWeight: 950, fontSize: '1.4rem',
+                marginBottom: 32, boxShadow: `6px 6px 0px ${T.accent}`
+              }}
+            >Q</div>
+            <h1
+              style={{
+                fontFamily: T.fontHead, fontWeight: 950, fontSize: '2.5rem',
+                letterSpacing: -1, textTransform: 'uppercase', marginBottom: 12
+              }}
+            >
               {isLogin ? 'Welcome Back' : 'Get Started'}
             </h1>
             <p style={{ fontFamily: T.fontMono, fontSize: '0.65rem', color: T.text3, textTransform: 'uppercase', letterSpacing: 1.5, fontWeight: 800 }}>
@@ -164,11 +150,13 @@ export function AuthPage() {
           </div>
 
           {error && (
-            <div style={{ 
-              padding: '16px', background: `${T.red}11`, border: `1px solid ${T.red}`, 
-              color: T.red, fontFamily: T.fontMono, fontSize: '0.7rem', fontWeight: 950, 
-              marginBottom: 32, textTransform: 'uppercase' 
-            }}>
+            <div
+              style={{
+                padding: '16px', background: `${T.red}11`, border: `1px solid ${T.red}`,
+                color: T.red, fontFamily: T.fontMono, fontSize: '0.7rem', fontWeight: 950,
+                marginBottom: 32, textTransform: 'uppercase'
+              }}
+            >
               {error}
             </div>
           )}
@@ -178,12 +166,15 @@ export function AuthPage() {
               <label style={{ display: 'block', fontFamily: T.fontMono, fontSize: '0.6rem', fontWeight: 950, letterSpacing: 1.5, marginBottom: 8, color: T.text3, textTransform: 'uppercase' }}>Email Address</label>
               <div style={{ position: 'relative' }}>
                 <Mail size={16} style={{ position: 'absolute', left: 16, top: '50%', transform: 'translateY(-50%)', color: T.text3 }} />
-                <input 
-                  type="email" required value={email} onChange={e => setEmail(e.target.value)}
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
                   placeholder="name@company.com"
                   style={{
-                    width: '100%', padding: '16px 16px 16px 48px', background: T.s2, 
-                    border: `1px solid ${T.border}`, fontFamily: T.fontMono, fontSize: '0.8rem', 
+                    width: '100%', padding: '16px 16px 16px 48px', background: T.s2,
+                    border: `1px solid ${T.border}`, fontFamily: T.fontMono, fontSize: '0.8rem',
                     color: T.text, outline: 'none', transition: 'all 0.2s'
                   }}
                   onFocus={e => e.currentTarget.style.borderColor = T.accent}
@@ -196,12 +187,15 @@ export function AuthPage() {
               <label style={{ display: 'block', fontFamily: T.fontMono, fontSize: '0.6rem', fontWeight: 950, letterSpacing: 1.5, marginBottom: 8, color: T.text3, textTransform: 'uppercase' }}>Password</label>
               <div style={{ position: 'relative' }}>
                 <LockKeyhole size={16} style={{ position: 'absolute', left: 16, top: '50%', transform: 'translateY(-50%)', color: T.text3 }} />
-                <input 
-                  type="password" required value={password} onChange={e => setPassword(e.target.value)}
-                  placeholder="••••••••••••"
+                <input
+                  type="password"
+                  required
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="............"
                   style={{
-                    width: '100%', padding: '16px 16px 16px 48px', background: T.s2, 
-                    border: `1px solid ${T.border}`, fontFamily: T.fontMono, fontSize: '0.8rem', 
+                    width: '100%', padding: '16px 16px 16px 48px', background: T.s2,
+                    border: `1px solid ${T.border}`, fontFamily: T.fontMono, fontSize: '0.8rem',
                     color: T.text, outline: 'none', transition: 'all 0.2s'
                   }}
                   onFocus={e => e.currentTarget.style.borderColor = T.accent}
@@ -210,11 +204,12 @@ export function AuthPage() {
               </div>
             </div>
 
-            <button 
-              type="submit" disabled={loading}
+            <button
+              type="submit"
+              disabled={loading}
               style={{
-                background: T.text, color: T.bg, padding: '18px', fontWeight: 950, 
-                fontFamily: T.fontMono, fontSize: '0.8rem', textTransform: 'uppercase', 
+                background: T.text, color: T.bg, padding: '18px', fontWeight: 950,
+                fontFamily: T.fontMono, fontSize: '0.8rem', textTransform: 'uppercase',
                 letterSpacing: 3, border: 'none', cursor: 'pointer',
                 transition: 'all 0.3s cubic-bezier(0.2, 0.8, 0.2, 1)',
                 display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12
@@ -229,29 +224,27 @@ export function AuthPage() {
 
           <div style={{ display: 'flex', alignItems: 'center', margin: '40px 0', color: T.border }}>
             <div style={{ flex: 1, height: 1, background: T.border }} />
-            <span style={{ padding: '0 20px', fontFamily: T.fontMono, fontSize: '0.6rem', fontWeight: 950, letterSpacing: 2 }}>OR CONTINUE WITH</span>
+            <span style={{ padding: '0 20px', fontFamily: T.fontMono, fontSize: '0.6rem', fontWeight: 950, letterSpacing: 2 }}>GOOGLE OAUTH DEFERRED</span>
             <div style={{ flex: 1, height: 1, background: T.border }} />
           </div>
 
-          <button 
-            onClick={() => handleOAuthLogin('google')}
+          <button
+            disabled
             style={{
-              width: '100%', padding: '16px', background: 'transparent', 
-              border: `1px solid ${T.border}`, color: T.text, fontWeight: 950, 
-              fontFamily: T.fontMono, fontSize: '0.75rem', textTransform: 'uppercase', 
-              letterSpacing: 2, cursor: 'pointer', transition: 'all 0.2s',
+              width: '100%', padding: '16px', background: 'transparent',
+              border: `1px solid ${T.border}`, color: T.text3, fontWeight: 950,
+              fontFamily: T.fontMono, fontSize: '0.75rem', textTransform: 'uppercase',
+              letterSpacing: 2, cursor: 'not-allowed', opacity: 0.65,
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12
             }}
-            onMouseEnter={e => { e.currentTarget.style.background = T.s1; e.currentTarget.style.borderColor = T.text; }}
-            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.borderColor = T.border; }}
           >
             <Globe size={16} />
-            Google Identity
+            Google Identity Soon
           </button>
 
           <p style={{ textAlign: 'center', marginTop: 40, fontFamily: T.fontMono, fontSize: '0.65rem', color: T.text3, fontWeight: 800, textTransform: 'uppercase', letterSpacing: 1 }}>
-            {isLogin ? "Don't have an account?" : "Already have an account?"}
-            <button 
+            {isLogin ? "Don't have an account?" : 'Already have an account?'}
+            <button
               onClick={() => setIsLogin(!isLogin)}
               style={{ background: 'none', border: 'none', color: T.accent, fontWeight: 950, cursor: 'pointer', marginLeft: 8, textTransform: 'uppercase' }}
             >
@@ -260,13 +253,6 @@ export function AuthPage() {
           </p>
         </div>
       </div>
-
-      <style>{`
-        @media (max-width: 1100px) {
-          .auth-visual { display: none; }
-          .auth-form-container { width: 100%; border: none; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,22 @@
+import { jsonRequest, request } from './http';
+import type { AuthCredentialsRequest, AuthSessionResponse } from '../types/api';
+
+export function signUp(data: AuthCredentialsRequest) {
+  return jsonRequest<AuthSessionResponse>('/auth/signup', 'POST', data);
+}
+
+export function signIn(data: AuthCredentialsRequest) {
+  return jsonRequest<AuthSessionResponse>('/auth/login', 'POST', data);
+}
+
+export function signOut() {
+  return request<{ message: string; status?: string | null }>('/auth/logout', { method: 'POST' });
+}
+
+export function refreshAuthSession() {
+  return request<AuthSessionResponse>('/auth/refresh', { method: 'POST', skipAuthRedirect: true });
+}
+
+export function getAuthSession() {
+  return request<AuthSessionResponse>('/auth/session', { skipAuthRedirect: true });
+}

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -1,8 +1,11 @@
 import { API_BASE } from '../config';
-import { supabase } from '../lib/supabase';
 import type { ApiErrorResponse } from '../types/api';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+type ApiRequestInit = RequestInit & {
+  skipAuthRedirect?: boolean;
+};
 
 function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
   return typeof value === 'object' && value !== null && 'error' in value;
@@ -29,27 +32,24 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
-export async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  // Get the current session token to send to the backend
-  const { data: { session } } = await supabase.auth.getSession();
-  const token = session?.access_token;
-
+export async function request<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  const { skipAuthRedirect, ...fetchInit } = init || {};
   const response = await fetch(`${API_BASE}${path}`, {
-    ...init,
+    ...fetchInit,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-      ...(init?.headers || {}),
+      ...(fetchInit.headers || {}),
     },
   });
 
   const payload = await parseResponseBody(response);
   if (!response.ok) {
-    if (response.status === 401) {
-      // Force sign out if the backend rejects the token (Database Truth Check failed)
-      console.warn("Session invalid or user deleted. Forcing sign out.");
-      await supabase.auth.signOut();
-      window.location.href = '/'; // Kick to landing page
+    if (response.status === 401 && !skipAuthRedirect) {
+      console.warn('Session invalid or expired. Redirecting to auth.');
+      if (window.location.pathname !== '/auth') {
+        window.location.href = '/auth';
+      }
     }
     throw new Error(getErrorMessage(payload, `Request failed with status ${response.status}`));
   }
@@ -57,8 +57,9 @@ export async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return payload as T;
 }
 
-export function jsonRequest<T>(path: string, method: HttpMethod, body?: unknown): Promise<T> {
+export function jsonRequest<T>(path: string, method: HttpMethod, body?: unknown, init?: Omit<ApiRequestInit, 'method' | 'body'>): Promise<T> {
   return request<T>(path, {
+    ...init,
     method,
     body: body ? JSON.stringify(body) : undefined,
   });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,6 +13,21 @@ export interface ApiErrorResponse {
   error: ApiErrorDetail;
 }
 
+export interface AuthCredentialsRequest {
+  email: string;
+  password: string;
+}
+
+export interface AuthUserResponse {
+  id: string;
+  email?: string | null;
+}
+
+export interface AuthSessionResponse {
+  authenticated: boolean;
+  user: AuthUserResponse | null;
+  message?: string | null;
+}
 export interface ChartRecommendation {
   type: 'bar' | 'line' | 'pie' | 'scatter' | 'area' | 'table' | 'kpi';
   x_column: string;
@@ -492,3 +507,4 @@ export interface AnalyticsOverviewResponse {
   top_connections: AnalyticsTopConnection[];
   recent_queries: AnalyticsRecentQuery[];
 }
+


### PR DESCRIPTION
## What changed

This PR moves auth ownership from the frontend to the backend while keeping Supabase Auth as the identity provider and local JWT verification as the steady-state request path.

It includes:
- new backend auth routes for signup, login, logout, refresh, and session
- a backend auth service for Supabase Auth calls, cookie issuance, and onboarding bootstrap
- cookie-first auth verification with temporary Authorization-header fallback
- frontend auth migration from direct Supabase JS calls to backend session endpoints
- backend auth tests covering cookie auth, header fallback, onboarding bootstrap, and dev-mode bypass
- removal of the unused frontend Supabase npm dependency
- shared frontend API auth types

## Why it changed

The previous setup made the frontend responsible for direct Supabase login/session handling and token propagation to the backend. This change centralizes auth behavior in the backend, moves the browser to HttpOnly cookie-based sessions, and keeps request-time verification local instead of turning Supabase into a per-request dependency.

## Impact

- frontend login/signup/logout/session calls now go to backend endpoints
- backend issues and clears auth cookies
- protected backend routes accept cookie auth first and bearer headers temporarily during migration
- onboarding is folded into auth bootstrap rather than being frontend-driven
- Google OAuth is intentionally deferred in this phase

## Validation

- python -m pytest -q
- 
pm.cmd run build

## Notes

Docs files were intentionally left out of this PR and remain uncommitted in the working tree.
