### PR TITLE
[codex] Harden frontend auth session UX

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,4 +1,28 @@
 const fallbackApiBase = 'http://localhost:8000/api';
 
-export const API_BASE =
-  import.meta.env.VITE_API_BASE_URL?.trim().replace(/\/$/, '') || fallbackApiBase;
+function normalizeLoopbackApiBase(rawApiBase: string): string {
+  const apiBase = rawApiBase.trim().replace(/\/$/, '') || fallbackApiBase;
+
+  if (typeof window === 'undefined') {
+    return apiBase;
+  }
+
+  try {
+    const apiUrl = new URL(apiBase);
+    const browserHost = window.location.hostname;
+    const loopbackHosts = new Set(['localhost', '127.0.0.1']);
+
+    if (loopbackHosts.has(apiUrl.hostname) && loopbackHosts.has(browserHost)) {
+      apiUrl.hostname = browserHost;
+      return apiUrl.toString().replace(/\/$/, '');
+    }
+  } catch {
+    return apiBase;
+  }
+
+  return apiBase;
+}
+
+export const API_BASE = normalizeLoopbackApiBase(
+  import.meta.env.VITE_API_BASE_URL || fallbackApiBase
+);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { T } from '../components/dashboard/tokens';
 import {
   getAuthSession,
+  refreshAuthSession as refreshAuthSessionRequest,
   signIn as signInRequest,
   signOut as signOutRequest,
   signUp as signUpRequest,
 } from '../services/auth';
+import { ApiRequestError } from '../services/http';
 import type { AuthSessionResponse, AuthUserResponse } from '../types/api';
 
 interface AuthContextType {
@@ -25,6 +28,47 @@ const MOCK_USER: AuthUserResponse = {
   email: 'dev@query-mind.com',
 };
 
+function SessionBootstrapScreen() {
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: T.bg,
+      color: T.text,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontFamily: T.fontMono,
+    }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        padding: '18px 22px',
+        border: `1px solid ${T.border}`,
+        background: T.s1,
+        boxShadow: `6px 6px 0px ${T.accent}`,
+      }}>
+        <div style={{
+          width: 28,
+          height: 28,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: T.text,
+          color: T.bg,
+          fontFamily: T.fontHead,
+          fontWeight: 950,
+        }}>
+          Q
+        </div>
+        <div style={{ fontSize: '0.72rem', fontWeight: 900, letterSpacing: 1.4, textTransform: 'uppercase' }}>
+          Restoring secure session
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<AuthUserResponse | null>(DEV_MODE ? MOCK_USER : null);
   const [loading, setLoading] = useState(!DEV_MODE);
@@ -39,7 +83,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const session = await getAuthSession();
       setUser(session.authenticated ? session.user : null);
       return session;
-    } catch {
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 401) {
+        try {
+          const refreshedSession = await refreshAuthSessionRequest();
+          setUser(refreshedSession.authenticated ? refreshedSession.user : null);
+          return refreshedSession;
+        } catch {
+          setUser(null);
+          return null;
+        }
+      }
+
       setUser(null);
       return null;
     }
@@ -81,7 +136,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <AuthContext.Provider value={{ user, loading, signIn, signUp, signOut, refreshSession, isDevMode: DEV_MODE }}>
-      {!loading && children}
+      {loading ? <SessionBootstrapScreen /> : children}
     </AuthContext.Provider>
   );
 };
@@ -93,4 +148,3 @@ export const useAuth = () => {
   }
   return context;
 };
-

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -4,6 +4,23 @@ import { T } from '../components/dashboard/tokens';
 import { useAuth } from '../context/AuthContext';
 import { Mail, ChevronRight, Activity, Globe, LockKeyhole } from 'lucide-react';
 import { LandingOverlay } from '../components/landing/LandingOverlay';
+import { ApiRequestError } from '../services/http';
+
+function authErrorMessage(error: unknown, isLogin: boolean): string {
+  if (error instanceof ApiRequestError) {
+    if (isLogin && error.status === 401) {
+      return 'INVALID EMAIL OR PASSWORD';
+    }
+    if (!isLogin && [400, 422].includes(error.status)) {
+      return 'COULD NOT CREATE ACCOUNT. CHECK EMAIL AND PASSWORD';
+    }
+    if (error.status === 0 || error.status === 503 || error.code === 'network_error' || error.code === 'service_unavailable') {
+      return 'AUTHENTICATION IS TEMPORARILY UNAVAILABLE';
+    }
+  }
+
+  return 'AUTHENTICATION FAILED. PLEASE TRY AGAIN';
+}
 
 export function AuthPage() {
   const navigate = useNavigate();
@@ -52,8 +69,8 @@ export function AuthPage() {
       }
 
       setError((session.message || 'Check your email to complete sign up.').toUpperCase());
-    } catch (err: any) {
-      setError(err.message?.toUpperCase() || 'AUTHENTICATION_FAILURE');
+    } catch (err) {
+      setError(authErrorMessage(err, isLogin));
     } finally {
       setLoading(false);
     }
@@ -168,6 +185,8 @@ export function AuthPage() {
                 <Mail size={16} style={{ position: 'absolute', left: 16, top: '50%', transform: 'translateY(-50%)', color: T.text3 }} />
                 <input
                   type="email"
+                  name="email"
+                  autoComplete="email"
                   required
                   value={email}
                   onChange={e => setEmail(e.target.value)}
@@ -189,6 +208,8 @@ export function AuthPage() {
                 <LockKeyhole size={16} style={{ position: 'absolute', left: 16, top: '50%', transform: 'translateY(-50%)', color: T.text3 }} />
                 <input
                   type="password"
+                  name="password"
+                  autoComplete={isLogin ? 'current-password' : 'new-password'}
                   required
                   value={password}
                   onChange={e => setPassword(e.target.value)}
@@ -245,7 +266,10 @@ export function AuthPage() {
           <p style={{ textAlign: 'center', marginTop: 40, fontFamily: T.fontMono, fontSize: '0.65rem', color: T.text3, fontWeight: 800, textTransform: 'uppercase', letterSpacing: 1 }}>
             {isLogin ? "Don't have an account?" : 'Already have an account?'}
             <button
-              onClick={() => setIsLogin(!isLogin)}
+              onClick={() => {
+                setIsLogin(!isLogin);
+                setError(null);
+              }}
               style={{ background: 'none', border: 'none', color: T.accent, fontWeight: 950, cursor: 'pointer', marginLeft: 8, textTransform: 'uppercase' }}
             >
               {isLogin ? 'Sign Up' : 'Sign In'}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -2,21 +2,21 @@ import { jsonRequest, request } from './http';
 import type { AuthCredentialsRequest, AuthSessionResponse } from '../types/api';
 
 export function signUp(data: AuthCredentialsRequest) {
-  return jsonRequest<AuthSessionResponse>('/auth/signup', 'POST', data);
+  return jsonRequest<AuthSessionResponse>('/auth/signup', 'POST', data, { skipAuthRefresh: true });
 }
 
 export function signIn(data: AuthCredentialsRequest) {
-  return jsonRequest<AuthSessionResponse>('/auth/login', 'POST', data);
+  return jsonRequest<AuthSessionResponse>('/auth/login', 'POST', data, { skipAuthRefresh: true });
 }
 
 export function signOut() {
-  return request<{ message: string; status?: string | null }>('/auth/logout', { method: 'POST' });
+  return request<{ message: string; status?: string | null }>('/auth/logout', { method: 'POST', skipAuthRefresh: true });
 }
 
 export function refreshAuthSession() {
-  return request<AuthSessionResponse>('/auth/refresh', { method: 'POST', skipAuthRedirect: true });
+  return request<AuthSessionResponse>('/auth/refresh', { method: 'POST', skipAuthRedirect: true, skipAuthRefresh: true });
 }
 
 export function getAuthSession() {
-  return request<AuthSessionResponse>('/auth/session', { skipAuthRedirect: true });
+  return request<AuthSessionResponse>('/auth/session', { skipAuthRedirect: true, skipAuthRefresh: true });
 }

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -2,10 +2,38 @@ import { API_BASE } from '../config';
 import type { ApiErrorResponse } from '../types/api';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type ApiErrorDetails = NonNullable<ApiErrorResponse['error']['details']>;
 
 type ApiRequestInit = RequestInit & {
   skipAuthRedirect?: boolean;
+  skipAuthRefresh?: boolean;
 };
+
+const AUTH_REFRESH_PATH = '/auth/refresh';
+const AUTH_RETRY_EXCLUDED_PATHS = new Set([
+  '/auth/login',
+  '/auth/signup',
+  '/auth/logout',
+  '/auth/refresh',
+  '/auth/session',
+]);
+
+export class ApiRequestError extends Error {
+  status: number;
+  code: string;
+  details: ApiErrorDetails | null;
+
+  constructor(
+    message: string,
+    options: { status: number; code: string; details?: ApiErrorDetails | null }
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.status = options.status;
+    this.code = options.code;
+    this.details = options.details ?? null;
+  }
+}
 
 function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
   return typeof value === 'object' && value !== null && 'error' in value;
@@ -32,26 +60,107 @@ function getErrorMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
-export async function request<T>(path: string, init?: ApiRequestInit): Promise<T> {
-  const { skipAuthRedirect, ...fetchInit } = init || {};
-  const response = await fetch(`${API_BASE}${path}`, {
+function getErrorCode(payload: unknown, fallback: string): string {
+  return isApiErrorResponse(payload) ? payload.error.code : fallback;
+}
+
+function getErrorDetails(payload: unknown): ApiErrorDetails | null {
+  return isApiErrorResponse(payload) ? payload.error.details ?? null : null;
+}
+
+function buildFetchInit(init?: ApiRequestInit): RequestInit {
+  const fetchInit: ApiRequestInit = { ...(init || {}) };
+  delete fetchInit.skipAuthRedirect;
+  delete fetchInit.skipAuthRefresh;
+
+  const headers = new Headers(fetchInit.headers);
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  return {
     ...fetchInit,
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(fetchInit.headers || {}),
-    },
-  });
+    headers,
+  };
+}
+
+function shouldRefreshAuth(path: string, init?: ApiRequestInit): boolean {
+  const routePath = path.split('?')[0];
+  if (init?.skipAuthRefresh) return false;
+  return !AUTH_RETRY_EXCLUDED_PATHS.has(routePath);
+}
+
+async function fetchApi(path: string, init?: ApiRequestInit): Promise<{ response: Response; payload: unknown }> {
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}${path}`, buildFetchInit(init));
+  } catch {
+    throw new ApiRequestError('Network request failed.', {
+      status: 0,
+      code: 'network_error',
+    });
+  }
 
   const payload = await parseResponseBody(response);
-  if (!response.ok) {
-    if (response.status === 401 && !skipAuthRedirect) {
-      console.warn('Session invalid or expired. Redirecting to auth.');
-      if (window.location.pathname !== '/auth') {
-        window.location.href = '/auth';
+  return { response, payload };
+}
+
+async function tryRefreshAuth(): Promise<boolean> {
+  try {
+    const response = await fetch(`${API_BASE}${AUTH_REFRESH_PATH}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function handleAuthRedirect(skipAuthRedirect?: boolean) {
+  if (skipAuthRedirect) return;
+
+  console.warn('Session invalid or expired. Redirecting to auth.');
+  if (window.location.pathname !== '/auth') {
+    window.location.href = '/auth';
+  }
+}
+
+function requestErrorFromResponse(response: Response, payload: unknown): ApiRequestError {
+  const message = getErrorMessage(payload, `Request failed with status ${response.status}`);
+  return new ApiRequestError(message, {
+    status: response.status,
+    code: getErrorCode(payload, `http_${response.status}`),
+    details: getErrorDetails(payload),
+  });
+}
+
+export async function request<T>(path: string, init?: ApiRequestInit): Promise<T> {
+  const { response, payload } = await fetchApi(path, init);
+
+  if (response.status === 401 && shouldRefreshAuth(path, init)) {
+    const refreshed = await tryRefreshAuth();
+    if (refreshed) {
+      const retry = await fetchApi(path, { ...init, skipAuthRefresh: true });
+      if (retry.response.ok) {
+        return retry.payload as T;
       }
+      if (retry.response.status === 401) {
+        handleAuthRedirect(init?.skipAuthRedirect);
+      }
+      throw requestErrorFromResponse(retry.response, retry.payload);
     }
-    throw new Error(getErrorMessage(payload, `Request failed with status ${response.status}`));
+  }
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      handleAuthRedirect(init?.skipAuthRedirect);
+    }
+    throw requestErrorFromResponse(response, payload);
   }
 
   return payload as T;
@@ -64,3 +173,4 @@ export function jsonRequest<T>(path: string, method: HttpMethod, body?: unknown,
     body: body ? JSON.stringify(body) : undefined,
   });
 }
+

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -173,4 +173,3 @@ export function jsonRequest<T>(path: string, method: HttpMethod, body?: unknown,
     body: body ? JSON.stringify(body) : undefined,
   });
 }
-


### PR DESCRIPTION
## Summary

- add cookie-session refresh recovery during frontend auth bootstrap
- retry eligible protected API requests once after a successful auth refresh
- normalize local loopback API hosts between localhost and 127.0.0.1
- map auth failures to stable UI messages and add browser autocomplete attributes
- show a minimal query-mind session bootstrap screen instead of a blank app

## Impact

This keeps users signed in when the access cookie expires but the refresh cookie is still valid, improves local dev host consistency, and hardens the auth page UX without changing backend public API contracts.

Excluded from this PR by request:

- `.agents/skills/`
- `.codex/`
- `backend/celerybeat-schedule.dat`
- `backend/celerybeat-schedule.dir`
- `docs/`

## Validation

- `python -m pytest backend/tests/test_auth_backend.py -q` -> 9 passed
- `npm.cmd run build` -> passed
- `git diff --check main..HEAD` -> passed
- Manual browser QA covered wrong-password error, login, protected refresh persistence, access-cookie refresh recovery, logout, protected-route redirect after logout, and autocomplete attributes

Note: Vite still reports the existing large chunk warning during build.