### PR TITLE
[codex] Harden chat SQL QA flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ extra_assets/
 backend/pip_list.txt
 backend/test_*.py
 test_*.py
+!backend/tests/test_*.py
 CHAT_TEST_GUIDE.md
 BACKEND_STRUCTURE_PROPOSAL.md
 *.seed.sql

--- a/backend/app/agents/nl_to_sql/graph.py
+++ b/backend/app/agents/nl_to_sql/graph.py
@@ -27,6 +27,7 @@ class ChatState(TypedDict):
     rows: list[dict]
     row_count: int
     execution_time_ms: float
+    truncated: bool
     error: str
     retry_count: int
     max_retries: int
@@ -96,6 +97,7 @@ def execute_sql_node(state: ChatState) -> dict:
             "rows": result.rows,
             "row_count": result.row_count,
             "execution_time_ms": result.execution_time_ms,
+            "truncated": result.truncated,
             "error": "",
         }
 
@@ -210,6 +212,7 @@ def run_chat(
         "rows": [],
         "row_count": 0,
         "execution_time_ms": 0.0,
+        "truncated": False,
         "error": "",
         "retry_count": 0,
         "max_retries": 3,

--- a/backend/app/api/v1/routes/chat.py
+++ b/backend/app/api/v1/routes/chat.py
@@ -35,6 +35,8 @@ async def send_chat_message(
             session_id=request.session_id,
         )
         return ChatResponse.model_validate(result)
+    except chat_service.ChatPersistenceError as exc:
+        raise ServiceUnavailableError("Unable to persist chat state for this request.") from exc
     except ValueError as exc:
         detail = str(exc)
         if "not found" in detail.lower():
@@ -101,6 +103,8 @@ async def edit_chat_sql(
         raise NotFoundError(str(exc)) from exc
     except chat_service.ChatEditValidationError as exc:
         raise BadRequestError(str(exc)) from exc
+    except chat_service.ChatPersistenceError as exc:
+        raise ServiceUnavailableError("Unable to persist chat state for this request.") from exc
     except Exception as exc:
         raise ServiceUnavailableError("Unable to re-run the edited SQL at the moment.") from exc
 

--- a/backend/app/api/v1/routes/chat.py
+++ b/backend/app/api/v1/routes/chat.py
@@ -97,8 +97,10 @@ async def edit_chat_sql(
             request.sql,
             request.connection_id,
         )
-    except ValueError as exc:
+    except chat_service.ChatEditNotFoundError as exc:
         raise NotFoundError(str(exc)) from exc
+    except chat_service.ChatEditValidationError as exc:
+        raise BadRequestError(str(exc)) from exc
     except Exception as exc:
         raise ServiceUnavailableError("Unable to re-run the edited SQL at the moment.") from exc
 

--- a/backend/app/api/v1/schemas/chat.py
+++ b/backend/app/api/v1/schemas/chat.py
@@ -1,7 +1,11 @@
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+CHAT_MESSAGE_MAX_LENGTH = 2048
+EDIT_SQL_MAX_LENGTH = 20000
 
 
 class ChartRecommendation(BaseModel):
@@ -22,9 +26,26 @@ class ChartRecommendation(BaseModel):
 class ChatRequest(BaseModel):
     """Request to send a chat message."""
 
-    connection_id: str
+    connection_id: str = Field(min_length=1)
     session_id: Optional[str] = None
-    message: str
+    message: str = Field(min_length=1, max_length=CHAT_MESSAGE_MAX_LENGTH)
+
+    @field_validator("connection_id", "message", mode="before")
+    @classmethod
+    def strip_required_strings(cls, value: str) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("session_id", mode="before")
+    @classmethod
+    def strip_optional_session_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
 
 
 class ChatResponse(BaseModel):
@@ -38,6 +59,7 @@ class ChatResponse(BaseModel):
     columns: list[str] = Field(default_factory=list)
     rows: list[dict] = Field(default_factory=list)
     row_count: int = 0
+    truncated: bool = False
     execution_time_ms: float = 0.0
     chart_recommendation: Optional[ChartRecommendation] = None
     error: Optional[str] = None
@@ -56,6 +78,7 @@ class ChatMessage(BaseModel):
     sql: Optional[str] = None
     results: Optional[dict] = None
     columns: list[str] = Field(default_factory=list)
+    truncated: bool = False
     chart_recommendation: Optional[Any] = None
     is_pinned: bool = False
     error: Optional[str] = None
@@ -107,11 +130,20 @@ class UpdateSessionRequest(BaseModel):
 class EditSqlRequest(BaseModel):
     """Request to edit SQL in a chat message and re-run it."""
 
-    sql: str
-    connection_id: str
+    sql: str = Field(min_length=1, max_length=EDIT_SQL_MAX_LENGTH)
+    connection_id: str = Field(min_length=1)
+
+    @field_validator("sql", "connection_id", mode="before")
+    @classmethod
+    def strip_required_strings(cls, value: str) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        return value
 
 
 __all__ = [
+    "CHAT_MESSAGE_MAX_LENGTH",
+    "EDIT_SQL_MAX_LENGTH",
     "ChartRecommendation",
     "ChatMessage",
     "ChatSession",

--- a/backend/app/db/models/chat.py
+++ b/backend/app/db/models/chat.py
@@ -15,6 +15,7 @@ class ChatMessage(BaseModel):
     sql: Optional[str] = None
     results: Optional[Dict] = None
     columns: List[str] = Field(default_factory=list)
+    truncated: bool = False
     chart_recommendation: Optional[Any] = None
     is_pinned: bool = False
     error: Optional[str] = None

--- a/backend/app/db/repositories/chat_repository.py
+++ b/backend/app/db/repositories/chat_repository.py
@@ -29,6 +29,7 @@ def _map_message(row: ChatMessageORM) -> ChatMessage:
         sql=row.sql,
         results=row.results,
         columns=row.columns or [],
+        truncated=bool((row.results or {}).get("truncated", False)),
         chart_recommendation=row.chart_recommendation,
         is_pinned=bool(row.is_pinned),
         error=row.error,
@@ -83,6 +84,18 @@ async def get_session(user_id: str, session_id: str) -> Optional[ChatSession]:
         messages = [_map_message(message_row) for message_row in message_rows]
         return _map_session(row, reconstruct_dual_chain(messages))
 
+async def get_message(user_id: str, session_id: str, message_id: str) -> Optional[ChatMessage]:
+    with session_scope() as db:
+        row = (
+            db.query(ChatMessageORM)
+            .filter(
+                ChatMessageORM.id == message_id,
+                ChatMessageORM.session_id == session_id,
+                ChatMessageORM.owner_id == user_id,
+            )
+            .one_or_none()
+        )
+        return _map_message(row) if row else None
 
 async def delete_session(user_id: str, session_id: str) -> bool:
     with session_scope() as db:
@@ -289,6 +302,7 @@ def reconstruct_dual_chain(messages: list[ChatMessage]) -> list[ChatMessage]:
 __all__ = [
     "create_session",
     "get_session",
+    "get_message",
     "delete_session",
     "list_sessions",
     "track_connection",

--- a/backend/app/db/repositories/chat_repository.py
+++ b/backend/app/db/repositories/chat_repository.py
@@ -161,109 +161,85 @@ async def track_connection(user_id: str, session_id: str, connection_id: str | N
 
 
 async def rename_session(user_id: str, session_id: str, title: str) -> bool:
-    try:
-        with session_scope() as db:
-            row = (
-                db.query(ChatSessionORM)
-                .filter(ChatSessionORM.id == session_id, ChatSessionORM.owner_id == user_id)
-                .one_or_none()
-            )
-            if not row:
-                return False
-            row.title = title
-            return True
-    except Exception as exc:
-        logger.warning("Error renaming session %s: %s", session_id, exc)
-        return False
-
+    with session_scope() as db:
+        row = (
+            db.query(ChatSessionORM)
+            .filter(ChatSessionORM.id == session_id, ChatSessionORM.owner_id == user_id)
+            .one_or_none()
+        )
+        if not row:
+            return False
+        row.title = title
+        return True
 
 async def add_message(user_id: str, session_id: str, message: ChatMessage) -> None:
-    try:
-        with session_scope() as db:
-            row = ChatMessageORM(
-                id=message.id,
-                session_id=session_id,
-                owner_id=user_id,
-                role=message.role,
-                content=message.content,
-                connection_id=message.connection_id,
-                sql=message.sql,
-                results=message.results,
-                columns=message.columns or [],
-                chart_recommendation=message.chart_recommendation,
-                is_pinned=message.is_pinned,
-                error=message.error,
-                parent_id=message.parent_id,
-                prev_query_id=message.prev_query_id,
-            )
-            db.add(row)
-    except Exception as exc:
-        logger.error("Error adding message %s to SQLAlchemy storage: %s", message.id, exc)
-
+    with session_scope() as db:
+        row = ChatMessageORM(
+            id=message.id,
+            session_id=session_id,
+            owner_id=user_id,
+            role=message.role,
+            content=message.content,
+            connection_id=message.connection_id,
+            sql=message.sql,
+            results=message.results,
+            columns=message.columns or [],
+            chart_recommendation=message.chart_recommendation,
+            is_pinned=message.is_pinned,
+            error=message.error,
+            parent_id=message.parent_id,
+            prev_query_id=message.prev_query_id,
+        )
+        db.add(row)
 
 async def update_message(user_id: str, session_id: str, message_id: str, updates: dict) -> bool:
-    try:
-        with session_scope() as db:
-            row = (
-                db.query(ChatMessageORM)
-                .filter(
-                    ChatMessageORM.id == message_id,
-                    ChatMessageORM.session_id == session_id,
-                    ChatMessageORM.owner_id == user_id,
-                )
-                .one_or_none()
+    with session_scope() as db:
+        row = (
+            db.query(ChatMessageORM)
+            .filter(
+                ChatMessageORM.id == message_id,
+                ChatMessageORM.session_id == session_id,
+                ChatMessageORM.owner_id == user_id,
             )
-            if not row:
-                return False
-            clean_updates = {key: value for key, value in updates.items() if value is not None}
-            for key, value in clean_updates.items():
-                if hasattr(row, key):
-                    setattr(row, key, value)
-            return True
-    except Exception as exc:
-        logger.error("Error updating message %s in session %s: %s", message_id, session_id, exc)
-        return False
-
+            .one_or_none()
+        )
+        if not row:
+            return False
+        clean_updates = {key: value for key, value in updates.items() if value is not None}
+        for key, value in clean_updates.items():
+            if hasattr(row, key):
+                setattr(row, key, value)
+        return True
 
 async def get_history_for_llm(user_id: str, session_id: str) -> list[dict]:
-    try:
-        with session_scope() as db:
-            rows = (
-                db.query(ChatMessageORM)
-                .filter(ChatMessageORM.session_id == session_id, ChatMessageORM.owner_id == user_id)
-                .order_by(ChatMessageORM.created_at.asc())
-                .all()
-            )
-            history: list[dict] = []
-            for row in rows:
-                content = row.content
-                if row.role == "assistant" and row.sql:
-                    content = f"{content}\n```sql\n{row.sql}\n```"
-                history.append({"role": row.role, "content": content})
-            return history
-    except Exception as exc:
-        logger.warning("Error fetching history for session %s: %s", session_id, exc)
-        return []
-
+    with session_scope() as db:
+        rows = (
+            db.query(ChatMessageORM)
+            .filter(ChatMessageORM.session_id == session_id, ChatMessageORM.owner_id == user_id)
+            .order_by(ChatMessageORM.created_at.asc())
+            .all()
+        )
+        history: list[dict] = []
+        for row in rows:
+            content = row.content
+            if row.role == "assistant" and row.sql:
+                content = f"{content}\n```sql\n{row.sql}\n```"
+            history.append({"role": row.role, "content": content})
+        return history
 
 async def get_latest_user_message_id(user_id: str, session_id: str) -> Optional[str]:
-    try:
-        with session_scope() as db:
-            row = (
-                db.query(ChatMessageORM.id)
-                .filter(
-                    ChatMessageORM.session_id == session_id,
-                    ChatMessageORM.owner_id == user_id,
-                    ChatMessageORM.role == "user",
-                )
-                .order_by(ChatMessageORM.created_at.desc())
-                .first()
+    with session_scope() as db:
+        row = (
+            db.query(ChatMessageORM.id)
+            .filter(
+                ChatMessageORM.session_id == session_id,
+                ChatMessageORM.owner_id == user_id,
+                ChatMessageORM.role == "user",
             )
-            return row.id if row else None
-    except Exception as exc:
-        logger.warning("Error fetching latest user message for session %s: %s", session_id, exc)
-        return None
-
+            .order_by(ChatMessageORM.created_at.desc())
+            .first()
+        )
+        return row.id if row else None
 
 def reconstruct_dual_chain(messages: list[ChatMessage]) -> list[ChatMessage]:
     """Reconstruct conversation order using prev_query_id and parent_id links."""

--- a/backend/app/query_engine/safety.py
+++ b/backend/app/query_engine/safety.py
@@ -66,11 +66,11 @@ def get_readonly_wrapped_query(sql: str) -> str:
 
 
 def sanitize_row_limit(sql: str, max_rows: int) -> str:
-    if re.search(r"\bLIMIT\b", sql, re.IGNORECASE):
-        return sql
-
-    sql = sql.rstrip(";").strip()
-    return f"{sql} LIMIT {max_rows}"
+    limit = max(1, int(max_rows))
+    normalized = sql.strip()
+    if normalized.endswith(";"):
+        normalized = normalized[:-1].rstrip()
+    return f"SELECT * FROM (\n{normalized}\n) AS qm_limited_query\nLIMIT {limit}"
 
 
 __all__ = [

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,6 +1,7 @@
 """Chat workflows."""
 
 import functools
+import logging
 
 import anyio
 
@@ -24,11 +25,18 @@ from app.db.repositories.chat_repository import (
 from app.services import connection_service, query_execution_service
 
 
+logger = logging.getLogger(__name__)
+
+
 class ChatEditNotFoundError(ValueError):
     pass
 
 
 class ChatEditValidationError(ValueError):
+    pass
+
+
+class ChatPersistenceError(RuntimeError):
     pass
 
 
@@ -56,14 +64,20 @@ async def send_message(
         schema_context = "No schema available. Please connect to a database first."
 
     is_new_session = False
-    if not session_id:
-        session = await create_session(user_id, connection_id)
-        session_id = session.id
-        is_new_session = True
-    else:
-        session = await get_session(user_id, session_id)
-        if not session:
-            raise ValueError("Session not found.")
+    try:
+        if not session_id:
+            session = await create_session(user_id, connection_id)
+            session_id = session.id
+            is_new_session = True
+        else:
+            session = await get_session(user_id, session_id)
+            if not session:
+                raise ValueError("Session not found.")
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to load or create chat session %s", session_id)
+        raise ChatPersistenceError("Unable to persist chat state for this request.") from exc
 
     await track_connection(user_id, session_id, connection_id)
 
@@ -71,17 +85,34 @@ async def send_message(
         title = message[:50].strip()
         if len(message) > 50:
             title += "..."
-        await rename_session(user_id, session_id, title)
+        try:
+            await rename_session(user_id, session_id, title)
+        except Exception:
+            logger.warning("Failed to rename new chat session %s", session_id, exc_info=True)
 
-    prev_query_id = await get_latest_user_message_id(user_id, session_id) if session_id else None
+    try:
+        prev_query_id = await get_latest_user_message_id(user_id, session_id) if session_id else None
+    except Exception as exc:
+        logger.exception("Failed to load latest user message for session %s", session_id)
+        raise ChatPersistenceError("Unable to persist chat state for this request.") from exc
+
     user_msg = ChatMessage(
         role="user",
         content=message,
         connection_id=connection_id,
         prev_query_id=prev_query_id,
     )
-    await add_message(user_id, session_id, user_msg)
-    history = await get_history_for_llm(user_id, session_id)
+    try:
+        await add_message(user_id, session_id, user_msg)
+    except Exception as exc:
+        logger.exception("Failed to persist user chat message %s", user_msg.id)
+        raise ChatPersistenceError("Unable to persist chat state for this request.") from exc
+
+    try:
+        history = await get_history_for_llm(user_id, session_id)
+    except Exception as exc:
+        logger.exception("Failed to load LLM history for session %s", session_id)
+        raise ChatPersistenceError("Unable to persist chat state for this request.") from exc
 
     result = await anyio.to_thread.run_sync(
         functools.partial(
@@ -115,7 +146,11 @@ async def send_message(
         parent_id=user_msg.id,
     )
     assistant_msg_id = assistant_msg.id
-    await add_message(user_id, session_id, assistant_msg)
+    try:
+        await add_message(user_id, session_id, assistant_msg)
+    except Exception as exc:
+        logger.exception("Failed to persist assistant chat message %s", assistant_msg.id)
+        raise ChatPersistenceError("Unable to persist chat state for this request.") from exc
 
     chart_rec = _sanitize_chart_recommendation(result.get("chart_recommendation"))
     error = result.get("error", "")
@@ -260,7 +295,7 @@ async def edit_message_sql(
 
     updated = await update_message(user_id, session_id, message_id, updates)
     if not updated:
-        raise RuntimeError("Edited SQL executed, but the chat message could not be updated.")
+        raise ChatPersistenceError("Edited SQL executed, but the chat message could not be updated.")
 
     return ChatMessage(
         id=message_id,
@@ -302,6 +337,7 @@ __all__ = [
     "edit_message_sql",
     "ChatEditNotFoundError",
     "ChatEditValidationError",
+    "ChatPersistenceError",
     "toggle_pin_status",
     "create_session",
     "get_session",

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -13,6 +13,7 @@ from app.db.repositories.chat_repository import (
     delete_session,
     get_history_for_llm,
     get_latest_user_message_id,
+    get_message,
     get_session,
     list_sessions,
     reconstruct_dual_chain,
@@ -21,6 +22,14 @@ from app.db.repositories.chat_repository import (
     update_message,
 )
 from app.services import connection_service, query_execution_service
+
+
+class ChatEditNotFoundError(ValueError):
+    pass
+
+
+class ChatEditValidationError(ValueError):
+    pass
 
 
 def _sanitize_chart_recommendation(chart_rec: dict | None) -> dict | None:
@@ -93,8 +102,14 @@ async def send_message(
         content=result.get("explanation", ""),
         connection_id=connection_id,
         sql=result.get("sql"),
-        results={"rows": result.get("rows", [])},
+        results={
+            "rows": result.get("rows", []),
+            "row_count": result.get("row_count", 0),
+            "execution_time_ms": result.get("execution_time_ms", 0.0),
+            "truncated": result.get("truncated", False),
+        },
         columns=result.get("columns", []),
+        truncated=result.get("truncated", False),
         chart_recommendation=result.get("chart_recommendation"),
         error=result.get("error"),
         parent_id=user_msg.id,
@@ -113,6 +128,7 @@ async def send_message(
         "columns": result.get("columns", []),
         "rows": result.get("rows", []),
         "row_count": result.get("row_count", 0),
+        "truncated": result.get("truncated", False),
         "execution_time_ms": result.get("execution_time_ms", 0.0),
         "chart_recommendation": chart_rec,
         "error": error if error else None,
@@ -184,6 +200,22 @@ async def edit_message_sql(
     sql: str,
     connection_id: str,
 ) -> ChatMessage:
+    session = await get_session(user_id, session_id)
+    if not session:
+        raise ChatEditNotFoundError("Session not found.")
+
+    message = await get_message(user_id, session_id, message_id)
+    if not message:
+        raise ChatEditNotFoundError("Message not found.")
+    if message.role != "assistant":
+        raise ChatEditValidationError("Only assistant SQL messages can be edited.")
+    if not message.sql:
+        raise ChatEditValidationError("This message does not contain editable SQL.")
+
+    engine = await connection_service.get_engine(user_id, connection_id)
+    if not engine:
+        raise ChatEditNotFoundError("Database connection not found.")
+
     result = await query_execution_service.execute_for_connection(
         user_id=user_id,
         connection_id=connection_id,
@@ -212,28 +244,41 @@ async def edit_message_sql(
 
     updates = {
         "sql": sql,
-        "results": {"rows": result.rows},
+        "results": {
+            "rows": result.rows,
+            "row_count": result.row_count,
+            "execution_time_ms": result.execution_time_ms,
+            "truncated": result.truncated,
+        },
         "columns": result.columns,
+        "truncated": result.truncated,
     }
     if new_viz is not None:
         updates["chart_recommendation"] = new_viz
     if result.error:
         updates["error"] = result.error
 
-    await update_message(user_id, session_id, message_id, updates)
+    updated = await update_message(user_id, session_id, message_id, updates)
+    if not updated:
+        raise RuntimeError("Edited SQL executed, but the chat message could not be updated.")
 
     return ChatMessage(
         id=message_id,
         role="assistant",
         content="SQL Updated & Re-run",
         sql=sql,
-        results={"rows": result.rows},
+        results={
+            "rows": result.rows,
+            "row_count": result.row_count,
+            "execution_time_ms": result.execution_time_ms,
+            "truncated": result.truncated,
+        },
         columns=result.columns,
+        truncated=result.truncated,
         chart_recommendation=new_viz,
         error=result.error,
         connection_id=connection_id,
     )
-
 
 async def toggle_pin_status(
     user_id: str,
@@ -255,9 +300,12 @@ __all__ = [
     "update_session_summary",
     "get_session_messages_response",
     "edit_message_sql",
+    "ChatEditNotFoundError",
+    "ChatEditValidationError",
     "toggle_pin_status",
     "create_session",
     "get_session",
+    "get_message",
     "delete_session",
     "list_sessions",
     "rename_session",

--- a/backend/tests/test_auth_backend.py
+++ b/backend/tests/test_auth_backend.py
@@ -369,9 +369,18 @@ def test_unsupported_database_connect_does_not_open_connection(client, monkeypat
 
 
 def test_saved_connection_diagnostic_updates_persistent_health(client, monkeypatch):
+    from cryptography.fernet import Fernet
+
+    from app.core import config as core_config
+    from app.core import secrets, security
     from app.db import connection_manager
     from app.db.models.connection import ConnectionRequest
     from app.db.repositories import connection_repository
+
+    monkeypatch.setenv("ENCRYPTION_KEY", Fernet.generate_key().decode("utf-8"))
+    core_config.get_settings.cache_clear()
+    secrets.settings = core_config.get_settings()
+    security._cipher_suite = None
 
     owner_id = "00000000-0000-0000-0000-000000000001"
     connection_id = asyncio.run(

--- a/backend/tests/test_chat_validation.py
+++ b/backend/tests/test_chat_validation.py
@@ -1,0 +1,68 @@
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.schemas.chat import (
+    CHAT_MESSAGE_MAX_LENGTH,
+    EDIT_SQL_MAX_LENGTH,
+    ChatRequest,
+    EditSqlRequest,
+)
+
+
+def test_chat_request_strips_valid_message_and_connection_id():
+    request = ChatRequest(connection_id=" conn_1 ", session_id=" session_1 ", message="  Show users  ")
+
+    assert request.connection_id == "conn_1"
+    assert request.session_id == "session_1"
+    assert request.message == "Show users"
+
+
+def test_chat_request_converts_blank_session_id_to_none():
+    request = ChatRequest(connection_id="conn_1", session_id="   ", message="Show users")
+
+    assert request.session_id is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"connection_id": "conn_1", "message": ""},
+        {"connection_id": "conn_1", "message": "   "},
+        {"connection_id": "", "message": "Show users"},
+        {"connection_id": "   ", "message": "Show users"},
+    ],
+)
+def test_chat_request_rejects_empty_required_fields(payload):
+    with pytest.raises(ValidationError):
+        ChatRequest(**payload)
+
+
+def test_chat_request_rejects_over_limit_message():
+    with pytest.raises(ValidationError):
+        ChatRequest(connection_id="conn_1", message="x" * (CHAT_MESSAGE_MAX_LENGTH + 1))
+
+
+def test_edit_sql_request_strips_valid_sql_and_connection_id():
+    request = EditSqlRequest(connection_id=" conn_1 ", sql="  SELECT 1  ")
+
+    assert request.connection_id == "conn_1"
+    assert request.sql == "SELECT 1"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"connection_id": "conn_1", "sql": ""},
+        {"connection_id": "conn_1", "sql": "   "},
+        {"connection_id": "", "sql": "SELECT 1"},
+        {"connection_id": "   ", "sql": "SELECT 1"},
+    ],
+)
+def test_edit_sql_request_rejects_empty_required_fields(payload):
+    with pytest.raises(ValidationError):
+        EditSqlRequest(**payload)
+
+
+def test_edit_sql_request_rejects_over_limit_sql():
+    with pytest.raises(ValidationError):
+        EditSqlRequest(connection_id="conn_1", sql="x" * (EDIT_SQL_MAX_LENGTH + 1))

--- a/backend/tests/test_safety.py
+++ b/backend/tests/test_safety.py
@@ -3,14 +3,20 @@
 Tests validate_query() and sanitize_row_limit() with a wide range of
 normal, edge-case, and adversarial inputs.
 """
+import asyncio
+from types import SimpleNamespace
+
 import anyio
 import pytest
+from sqlalchemy import create_engine, text
 from app.db.models.connection import ConnectionRequest
+from app.query_engine.executor import execute_query
 from app.query_engine.safety import (
     validate_query,
     sanitize_row_limit,
     get_readonly_wrapped_query,
 )
+from app.services import chat_service
 
 
 # ---------------------------------------------------------------------------
@@ -133,11 +139,11 @@ class TestSanitizeRowLimit:
         result = sanitize_row_limit(sql, 100)
         assert result.endswith("LIMIT 100")
 
-    def test_preserves_existing_limit(self):
+    def test_wraps_existing_limit_with_server_cap(self):
         sql = "SELECT * FROM users LIMIT 50"
         result = sanitize_row_limit(sql, 100)
         assert "LIMIT 50" in result
-        assert "LIMIT 100" not in result
+        assert result.endswith("LIMIT 100")
 
     def test_strips_trailing_semicolon_before_adding_limit(self):
         sql = "SELECT * FROM users;"
@@ -145,11 +151,18 @@ class TestSanitizeRowLimit:
         assert result.endswith("LIMIT 100")
         assert ";;" not in result
 
-    def test_case_insensitive_limit_detection(self):
+    def test_case_insensitive_existing_limit_still_gets_server_cap(self):
         sql = "SELECT * FROM users limit 20"
         result = sanitize_row_limit(sql, 100)
-        assert "LIMIT 100" not in result  # should keep existing limit
+        assert "limit 20" in result
+        assert result.endswith("LIMIT 100")
 
+
+    def test_wraps_cte_query_with_server_cap(self):
+        sql = "WITH users AS (SELECT 1 AS id) SELECT id FROM users"
+        result = sanitize_row_limit(sql, 100)
+        assert result.startswith("SELECT * FROM (\nWITH users AS")
+        assert result.endswith("LIMIT 100")
 
 # ---------------------------------------------------------------------------
 # get_readonly_wrapped_query
@@ -575,3 +588,294 @@ def test_connect_route_does_not_inspect_schema_or_bootstrap_templates(monkeypatc
 
     assert response.id == "conn_1"
     assert response.message == "Successfully connected to demo"
+
+# ---------------------------------------------------------------------------
+# execute_query row caps
+# ---------------------------------------------------------------------------
+
+class TestExecuteQueryRowLimits:
+    def test_enforces_row_limit_when_query_has_huge_limit(self):
+        engine = create_engine("sqlite:///:memory:")
+        with engine.begin() as conn:
+            conn.execute(text("CREATE TABLE items (id INTEGER PRIMARY KEY)"))
+            for i in range(10):
+                conn.execute(text("INSERT INTO items (id) VALUES (:id)"), {"id": i + 1})
+
+        result = execute_query(
+            user_id="user-1",
+            engine=engine,
+            sql="SELECT id FROM items ORDER BY id LIMIT 1000000",
+            row_limit=3,
+        )
+
+        assert result.success is True
+        assert result.row_count == 3
+        assert result.truncated is True
+        assert [row["id"] for row in result.rows] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# chat truncated metadata
+# ---------------------------------------------------------------------------
+
+class TestChatTruncatedMetadata:
+    def test_chat_response_and_stored_message_include_truncated(self, monkeypatch):
+        stored_messages = []
+
+        async def fake_get_engine(user_id, connection_id):
+            return object()
+
+        async def fake_get_schema_for_ai(user_id, connection_id):
+            return "Table: items\n  - id: integer NOT NULL"
+
+        async def fake_create_session(user_id, connection_id):
+            return SimpleNamespace(id="session-1")
+
+        async def fake_noop(*args, **kwargs):
+            return None
+
+        async def fake_get_history_for_llm(user_id, session_id):
+            return []
+
+        async def fake_get_latest_user_message_id(user_id, session_id):
+            return None
+
+        async def fake_add_message(user_id, session_id, message):
+            stored_messages.append(message)
+
+        def fake_run_chat(**kwargs):
+            return {
+                "explanation": "Preview is limited.",
+                "sql": "SELECT id FROM items LIMIT 1000000",
+                "columns": ["id"],
+                "rows": [{"id": 1}],
+                "row_count": 500,
+                "execution_time_ms": 12.5,
+                "truncated": True,
+                "chart_recommendation": None,
+                "error": "",
+                "column_metadata": {"id": "numeric"},
+            }
+
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.connection_service, "get_schema_for_ai", fake_get_schema_for_ai)
+        monkeypatch.setattr(chat_service, "create_session", fake_create_session)
+        monkeypatch.setattr(chat_service, "rename_session", fake_noop)
+        monkeypatch.setattr(chat_service, "track_connection", fake_noop)
+        monkeypatch.setattr(chat_service, "get_history_for_llm", fake_get_history_for_llm)
+        monkeypatch.setattr(chat_service, "get_latest_user_message_id", fake_get_latest_user_message_id)
+        monkeypatch.setattr(chat_service, "add_message", fake_add_message)
+        monkeypatch.setattr(chat_service, "run_chat", fake_run_chat)
+
+        response = asyncio.run(
+            chat_service.send_message(
+                user_id="user-1",
+                connection_id="connection-1",
+                message="show items",
+            )
+        )
+
+        assert response["truncated"] is True
+        assert response["row_count"] == 500
+        assert len(stored_messages) == 2
+        assistant_message = stored_messages[1]
+        assert assistant_message.truncated is True
+        assert assistant_message.results["truncated"] is True
+        assert assistant_message.results["row_count"] == 500
+        assert assistant_message.results["execution_time_ms"] == 12.5
+
+# ---------------------------------------------------------------------------
+# edit-SQL preflight validation
+# ---------------------------------------------------------------------------
+
+class TestEditSqlPreflight:
+    def test_missing_session_does_not_execute(self, monkeypatch):
+        executed = False
+
+        async def fake_get_session(user_id, session_id):
+            return None
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            nonlocal executed
+            executed = True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+
+        with pytest.raises(chat_service.ChatEditNotFoundError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "missing", "msg-1", "SELECT 1", "conn-1"))
+
+        assert executed is False
+
+    def test_missing_message_does_not_execute(self, monkeypatch):
+        executed = False
+
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return None
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            nonlocal executed
+            executed = True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+
+        with pytest.raises(chat_service.ChatEditNotFoundError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "missing", "SELECT 1", "conn-1"))
+
+        assert executed is False
+
+    def test_user_message_target_does_not_execute(self, monkeypatch):
+        executed = False
+
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return SimpleNamespace(role="user", sql=None)
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            nonlocal executed
+            executed = True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+
+        with pytest.raises(chat_service.ChatEditValidationError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 1", "conn-1"))
+
+        assert executed is False
+
+    def test_assistant_without_sql_does_not_execute(self, monkeypatch):
+        executed = False
+
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return SimpleNamespace(role="assistant", sql=None)
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            nonlocal executed
+            executed = True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+
+        with pytest.raises(chat_service.ChatEditValidationError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 1", "conn-1"))
+
+        assert executed is False
+
+    def test_missing_connection_does_not_execute(self, monkeypatch):
+        executed = False
+
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return SimpleNamespace(role="assistant", sql="SELECT 1")
+
+        async def fake_get_engine(user_id, connection_id):
+            return None
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            nonlocal executed
+            executed = True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+
+        with pytest.raises(chat_service.ChatEditNotFoundError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 1", "missing"))
+
+        assert executed is False
+
+    def test_valid_message_executes_and_updates(self, monkeypatch):
+        updates = []
+
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return SimpleNamespace(role="assistant", sql="SELECT 1")
+
+        async def fake_get_engine(user_id, connection_id):
+            return object()
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            return SimpleNamespace(
+                success=True,
+                rows=[],
+                columns=["id"],
+                row_count=0,
+                execution_time_ms=4.5,
+                truncated=False,
+                error=None,
+            )
+
+        async def fake_get_history_for_llm(user_id, session_id):
+            return []
+
+        async def fake_update_message(user_id, session_id, message_id, update):
+            updates.append(update)
+            return True
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+        monkeypatch.setattr(chat_service, "get_history_for_llm", fake_get_history_for_llm)
+        monkeypatch.setattr(chat_service, "update_message", fake_update_message)
+
+        response = asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 2", "conn-1"))
+
+        assert response.sql == "SELECT 2"
+        assert response.columns == ["id"]
+        assert updates[0]["results"]["execution_time_ms"] == 4.5
+        assert updates[0]["results"]["truncated"] is False
+
+    def test_failed_post_execution_update_raises_service_failure(self, monkeypatch):
+        async def fake_get_session(user_id, session_id):
+            return SimpleNamespace(id=session_id)
+
+        async def fake_get_message(user_id, session_id, message_id):
+            return SimpleNamespace(role="assistant", sql="SELECT 1")
+
+        async def fake_get_engine(user_id, connection_id):
+            return object()
+
+        async def fake_execute_for_connection(*args, **kwargs):
+            return SimpleNamespace(
+                success=True,
+                rows=[],
+                columns=["id"],
+                row_count=0,
+                execution_time_ms=4.5,
+                truncated=False,
+                error=None,
+            )
+
+        async def fake_get_history_for_llm(user_id, session_id):
+            return []
+
+        async def fake_update_message(user_id, session_id, message_id, update):
+            return False
+
+        monkeypatch.setattr(chat_service, "get_session", fake_get_session)
+        monkeypatch.setattr(chat_service, "get_message", fake_get_message)
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.query_execution_service, "execute_for_connection", fake_execute_for_connection)
+        monkeypatch.setattr(chat_service, "get_history_for_llm", fake_get_history_for_llm)
+        monkeypatch.setattr(chat_service, "update_message", fake_update_message)
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 2", "conn-1"))

--- a/backend/tests/test_safety.py
+++ b/backend/tests/test_safety.py
@@ -684,6 +684,163 @@ class TestChatTruncatedMetadata:
         assert assistant_message.results["row_count"] == 500
         assert assistant_message.results["execution_time_ms"] == 12.5
 
+
+# ---------------------------------------------------------------------------
+# chat persistence failure handling
+# ---------------------------------------------------------------------------
+
+class _BrokenSessionScope:
+    def __enter__(self):
+        raise RuntimeError("database unavailable")
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestChatPersistenceFailures:
+    def test_add_message_raises_on_db_failure(self, monkeypatch):
+        from app.db.models.chat import ChatMessage
+        from app.db.repositories import chat_repository
+
+        monkeypatch.setattr(chat_repository, "session_scope", lambda: _BrokenSessionScope())
+
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            asyncio.run(chat_repository.add_message("user-1", "session-1", ChatMessage(role="user", content="hi")))
+
+    def test_update_message_raises_on_db_failure(self, monkeypatch):
+        from app.db.repositories import chat_repository
+
+        monkeypatch.setattr(chat_repository, "session_scope", lambda: _BrokenSessionScope())
+
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            asyncio.run(chat_repository.update_message("user-1", "session-1", "message-1", {"content": "x"}))
+
+    def test_update_message_missing_message_returns_false(self):
+        from app.db.repositories import chat_repository
+
+        updated = asyncio.run(
+            chat_repository.update_message(
+                "00000000-0000-0000-0000-00000000ffff",
+                "00000000-0000-0000-0000-00000000aaa1",
+                "00000000-0000-0000-0000-00000000aaa2",
+                {"content": "x"},
+            )
+        )
+
+        assert updated is False
+
+    def test_get_history_for_llm_raises_on_db_failure(self, monkeypatch):
+        from app.db.repositories import chat_repository
+
+        monkeypatch.setattr(chat_repository, "session_scope", lambda: _BrokenSessionScope())
+
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            asyncio.run(chat_repository.get_history_for_llm("user-1", "session-1"))
+
+    def test_get_history_for_llm_empty_history_returns_empty_list(self):
+        from app.db.repositories import chat_repository
+
+        history = asyncio.run(
+            chat_repository.get_history_for_llm(
+                "00000000-0000-0000-0000-00000000ffff",
+                "00000000-0000-0000-0000-00000000aaa1",
+            )
+        )
+
+        assert history == []
+
+    def test_send_message_does_not_call_llm_when_user_message_persistence_fails(self, monkeypatch):
+        called_run_chat = False
+
+        async def fake_get_engine(user_id, connection_id):
+            return object()
+
+        async def fake_get_schema_for_ai(user_id, connection_id):
+            return "schema"
+
+        async def fake_create_session(user_id, connection_id):
+            return SimpleNamespace(id="session-1")
+
+        async def fake_noop(*args, **kwargs):
+            return True
+
+        async def fake_get_latest_user_message_id(user_id, session_id):
+            return None
+
+        async def fake_add_message(*args, **kwargs):
+            raise RuntimeError("write failed")
+
+        def fake_run_chat(*args, **kwargs):
+            nonlocal called_run_chat
+            called_run_chat = True
+            return {}
+
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.connection_service, "get_schema_for_ai", fake_get_schema_for_ai)
+        monkeypatch.setattr(chat_service, "create_session", fake_create_session)
+        monkeypatch.setattr(chat_service, "rename_session", fake_noop)
+        monkeypatch.setattr(chat_service, "track_connection", fake_noop)
+        monkeypatch.setattr(chat_service, "get_latest_user_message_id", fake_get_latest_user_message_id)
+        monkeypatch.setattr(chat_service, "add_message", fake_add_message)
+        monkeypatch.setattr(chat_service, "run_chat", fake_run_chat)
+
+        with pytest.raises(chat_service.ChatPersistenceError):
+            asyncio.run(chat_service.send_message("user-1", "connection-1", "show rows"))
+
+        assert called_run_chat is False
+
+    def test_send_message_fails_if_assistant_message_persistence_fails_after_llm(self, monkeypatch):
+        add_calls = 0
+
+        async def fake_get_engine(user_id, connection_id):
+            return object()
+
+        async def fake_get_schema_for_ai(user_id, connection_id):
+            return "schema"
+
+        async def fake_create_session(user_id, connection_id):
+            return SimpleNamespace(id="session-1")
+
+        async def fake_noop(*args, **kwargs):
+            return True
+
+        async def fake_get_latest_user_message_id(user_id, session_id):
+            return None
+
+        async def fake_get_history_for_llm(user_id, session_id):
+            return []
+
+        async def fake_add_message(*args, **kwargs):
+            nonlocal add_calls
+            add_calls += 1
+            if add_calls == 2:
+                raise RuntimeError("assistant write failed")
+
+        def fake_run_chat(*args, **kwargs):
+            return {
+                "explanation": "done",
+                "sql": "SELECT 1",
+                "columns": ["id"],
+                "rows": [{"id": 1}],
+                "row_count": 1,
+                "execution_time_ms": 1.0,
+                "truncated": False,
+            }
+
+        monkeypatch.setattr(chat_service.connection_service, "get_engine", fake_get_engine)
+        monkeypatch.setattr(chat_service.connection_service, "get_schema_for_ai", fake_get_schema_for_ai)
+        monkeypatch.setattr(chat_service, "create_session", fake_create_session)
+        monkeypatch.setattr(chat_service, "rename_session", fake_noop)
+        monkeypatch.setattr(chat_service, "track_connection", fake_noop)
+        monkeypatch.setattr(chat_service, "get_latest_user_message_id", fake_get_latest_user_message_id)
+        monkeypatch.setattr(chat_service, "get_history_for_llm", fake_get_history_for_llm)
+        monkeypatch.setattr(chat_service, "add_message", fake_add_message)
+        monkeypatch.setattr(chat_service, "run_chat", fake_run_chat)
+
+        with pytest.raises(chat_service.ChatPersistenceError):
+            asyncio.run(chat_service.send_message("user-1", "connection-1", "show rows"))
+
+        assert add_calls == 2
 # ---------------------------------------------------------------------------
 # edit-SQL preflight validation
 # ---------------------------------------------------------------------------
@@ -877,5 +1034,5 @@ class TestEditSqlPreflight:
         monkeypatch.setattr(chat_service, "get_history_for_llm", fake_get_history_for_llm)
         monkeypatch.setattr(chat_service, "update_message", fake_update_message)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(chat_service.ChatPersistenceError):
             asyncio.run(chat_service.edit_message_sql("user-1", "session-1", "msg-1", "SELECT 2", "conn-1"))

--- a/backend/tests/test_safety.py
+++ b/backend/tests/test_safety.py
@@ -697,6 +697,33 @@ class _BrokenSessionScope:
         return False
 
 
+class _EmptyQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def one_or_none(self):
+        return None
+
+    def all(self):
+        return []
+
+
+class _EmptySession:
+    def query(self, *args, **kwargs):
+        return _EmptyQuery()
+
+
+class _EmptySessionScope:
+    def __enter__(self):
+        return _EmptySession()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
 class TestChatPersistenceFailures:
     def test_add_message_raises_on_db_failure(self, monkeypatch):
         from app.db.models.chat import ChatMessage
@@ -715,8 +742,10 @@ class TestChatPersistenceFailures:
         with pytest.raises(RuntimeError, match="database unavailable"):
             asyncio.run(chat_repository.update_message("user-1", "session-1", "message-1", {"content": "x"}))
 
-    def test_update_message_missing_message_returns_false(self):
+    def test_update_message_missing_message_returns_false(self, monkeypatch):
         from app.db.repositories import chat_repository
+
+        monkeypatch.setattr(chat_repository, "session_scope", lambda: _EmptySessionScope())
 
         updated = asyncio.run(
             chat_repository.update_message(
@@ -737,8 +766,10 @@ class TestChatPersistenceFailures:
         with pytest.raises(RuntimeError, match="database unavailable"):
             asyncio.run(chat_repository.get_history_for_llm("user-1", "session-1"))
 
-    def test_get_history_for_llm_empty_history_returns_empty_list(self):
+    def test_get_history_for_llm_empty_history_returns_empty_list(self, monkeypatch):
         from app.db.repositories import chat_repository
+
+        monkeypatch.setattr(chat_repository, "session_scope", lambda: _EmptySessionScope())
 
         history = asyncio.run(
             chat_repository.get_history_for_llm(

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -2,16 +2,18 @@ import { useState, useRef } from 'react';
 import { T } from '../dashboard/tokens';
 import type { ChatInputProps } from '../../types/chat';
 
-export function ChatInput({ connections, activeConnectionId, onConnectionChange, onSend, loading }: ChatInputProps) {
+export function ChatInput({ connections, activeConnectionId, onConnectionChange, onSend, loading, disabled = false, disabledReason }: ChatInputProps) {
   const [text, setText] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
   const textRef = useRef<HTMLTextAreaElement>(null);
 
   const activeConn = connections.find(c => c.id === activeConnectionId);
+  const sendDisabled = disabled || loading || !text.trim();
+  const selectorDisabled = connections.length === 0;
 
   const handleSend = () => {
-    if (!text.trim() || loading) return;
+    if (!text.trim() || loading || disabled) return;
     onSend(text.trim());
     setText('');
   };
@@ -48,7 +50,8 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
           {/* DB Selector (Professional Style) */}
           <div style={{ position: 'relative', marginTop: 2 }}>
             <button
-              onClick={() => setShowDropdown(!showDropdown)}
+              onClick={() => { if (!selectorDisabled) setShowDropdown(!showDropdown); }}
+              disabled={selectorDisabled}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -57,7 +60,7 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
                 border: `1px solid rgba(0,0,0,0.1)`,
                 borderRadius: 0,
                 padding: '6px 12px',
-                cursor: 'pointer',
+                cursor: selectorDisabled ? 'default' : 'pointer',
                 color: T.text,
                 fontSize: '0.68rem',
                 fontFamily: T.fontMono,
@@ -71,7 +74,7 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
               onMouseLeave={e => { e.currentTarget.style.borderColor = 'rgba(0,0,0,0.1)'; }}
             >
               <div style={{ width: 5, height: 5, borderRadius: '50%', background: activeConn ? '#1a1a1a' : '#ef4444' }} />
-              {activeConn?.database || 'SELECT DB'}
+              {activeConn?.database || disabledReason || 'SELECT DB'}
               <span style={{ fontSize: '0.5rem', color: T.text3, marginLeft: 2 }}>▼</span>
             </button>
 
@@ -86,6 +89,11 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
                 boxShadow: '0 12px 32px rgba(0,0,0,0.1)',
                 zIndex: 100,
               }}>
+                {connections.length === 0 && (
+                  <div style={{ padding: '10px 14px', fontSize: '0.72rem', color: T.text3, fontFamily: T.fontMono, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    NO DATABASES AVAILABLE
+                  </div>
+                )}
                 {connections.map(c => (
                   <div key={c.id} onClick={e => { e.stopPropagation(); onConnectionChange(c.id); setShowDropdown(false); }}
                     style={{
@@ -113,7 +121,9 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
             onKeyDown={handleKeyDown}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            placeholder="What would you like to know?"
+            placeholder={disabledReason || 'What would you like to know?'}
+            disabled={disabled}
+            maxLength={2048}
             rows={2}
             style={{
               flex: 1,
@@ -136,14 +146,15 @@ export function ChatInput({ connections, activeConnectionId, onConnectionChange,
              <span style={{ fontSize: '0.62rem', color: T.text3, fontFamily: T.fontMono, fontWeight: 700 }}>{text.length} / 2048</span>
              <button
               onClick={handleSend}
-              disabled={loading || !text.trim()}
+              disabled={sendDisabled}
+              aria-label="Send message"
               style={{
                 width: 40,
                 height: 40,
                 borderRadius: 0,
-                background: text.trim() ? '#1a1a1a' : 'rgba(0,0,0,0.05)',
+                background: !sendDisabled ? '#1a1a1a' : 'rgba(0,0,0,0.05)',
                 border: 'none',
-                cursor: text.trim() ? 'pointer' : 'default',
+                cursor: !sendDisabled ? 'pointer' : 'default',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -145,6 +145,7 @@ export function MessageBubble({
                 rows={message.rows}
                 rowCount={message.row_count}
                 executionTime={message.execution_time_ms}
+                truncated={message.truncated}
               />
             </div>
           )}

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -6,7 +6,7 @@ import { BaseChartContainer } from '../charts/BaseChartContainer';
 import { AddToDashboardModal } from './AddToDashboardModal';
 import { SaveQueryModal } from './SaveQueryModal';
 import { useSmartSave } from '../../hooks/useSmartSave';
-import { Pin, Plus, RotateCcw, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Pin, Plus } from 'lucide-react';
 import type { ChatMessageView } from '../../types/chat';
 
 export function MessageBubble({
@@ -120,7 +120,7 @@ export function MessageBubble({
               onClick={() => message.sql && navigator.clipboard.writeText(message.sql)}
               style={{ background: 'none', border: 'none', color: T.text, fontSize: '0.65rem', fontWeight: 800, cursor: 'pointer', fontFamily: T.fontMono, textTransform: 'uppercase', letterSpacing: '0.05em' }}
             >
-              COPY LINK
+              COPY SQL
             </button>
           </div>
 
@@ -217,27 +217,6 @@ export function MessageBubble({
                 {message.is_pinned ? 'PINNED' : 'PIN RESULT'}
               </button>
             )}
-
-            <button
-              style={{
-                padding: '8px 16px', borderRadius: 0, border: `1.5px solid rgba(0,0,0,0.1)`,
-                background: 'transparent', color: T.text3,
-                fontSize: '0.7rem', fontWeight: 900, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 8, transition: 'all 0.2s',
-                fontFamily: T.fontMono, textTransform: 'uppercase', letterSpacing: '0.05em'
-              }}
-              onMouseEnter={e => { e.currentTarget.style.borderColor = '#1a1a1a'; e.currentTarget.style.color = '#1a1a1a'; }}
-              onMouseLeave={e => { e.currentTarget.style.borderColor = 'rgba(0,0,0,0.1)'; e.currentTarget.style.color = T.text3; }}
-            >
-              <RotateCcw size={12} strokeWidth={3} />
-              REGENERATE
-            </button>
-
-            <div style={{ flex: 1 }} />
-
-            <div style={{ display: 'flex', gap: 14, color: T.text3 }}>
-              <ThumbsUp size={16} strokeWidth={2} style={{ cursor: 'pointer', opacity: 0.5 }} />
-              <ThumbsDown size={16} strokeWidth={2} style={{ cursor: 'pointer', opacity: 0.5 }} />
-            </div>
           </div>
         </div>
       )}

--- a/frontend/src/components/chat/ResultsTable.tsx
+++ b/frontend/src/components/chat/ResultsTable.tsx
@@ -44,15 +44,7 @@ export function ResultsTable({ columns, rows, rowCount, executionTime, truncated
           {executionTime != null && ` · ${(executionTime / 1000).toFixed(2)}s`}
           {truncated && ' · limited'}
         </span>
-        <div style={{ display: 'flex', gap: 5 }}>
-          {['CSV', 'JSON'].map(f => (
-            <button key={f} style={{
-              padding: '4px 9px', borderRadius: 5, border: `1px solid ${T.border}`,
-              background: 'transparent', color: T.text3, fontSize: '0.68rem',
-              cursor: 'pointer', fontFamily: T.fontMono,
-            }}>{f}</button>
-          ))}
-        </div>
+
       </div>
 
       <div style={{ overflowX: 'auto', maxHeight: 200 }}>

--- a/frontend/src/components/chat/Sidebar.tsx
+++ b/frontend/src/components/chat/Sidebar.tsx
@@ -3,7 +3,7 @@ import { T } from '../dashboard/tokens';
 import type { ChatSidebarProps } from '../../types/chat';
 import { DeleteSessionModal } from './DeleteSessionModal';
 
-export function Sidebar({ sessions, activeSessionId, onSelectSession, onNewChat, onDeleteSession, onRenameSession, connections, activeConnectionId }: ChatSidebarProps) {
+export function Sidebar({ sessions, activeSessionId, sessionsState = 'ready', sessionsError, onRetrySessions, onSelectSession, onNewChat, onDeleteSession, onRenameSession, connections, activeConnectionId }: ChatSidebarProps) {
   const [search, setSearch] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
@@ -183,7 +183,23 @@ export function Sidebar({ sessions, activeSessionId, onSelectSession, onNewChat,
               })}
           </div>
         ))}
-        {sessions.length === 0 && (
+        {sessionsState === 'loading' && (
+          <div style={{ textAlign: 'center', padding: '48px 20px', color: T.text3, fontSize: '0.72rem', lineHeight: 1.7, fontFamily: T.fontMono, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            LOADING CONVERSATIONS
+          </div>
+        )}
+        {sessionsState === 'error' && (
+          <div style={{ textAlign: 'center', padding: '40px 14px', color: T.red, fontSize: '0.72rem', lineHeight: 1.7, fontFamily: T.fontMono, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            <div>CONVERSATION LOAD FAILED</div>
+            <div style={{ color: T.text3, fontSize: '0.62rem', marginTop: 8 }}>{sessionsError || 'COULD NOT LOAD CONVERSATIONS'}</div>
+            {onRetrySessions && (
+              <button onClick={onRetrySessions} style={{ marginTop: 14, padding: '8px 12px', background: '#fff', border: '1px solid rgba(0,0,0,0.12)', color: T.text, fontFamily: T.fontMono, fontWeight: 800, fontSize: '0.65rem', cursor: 'pointer', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                RETRY CONVERSATIONS
+              </button>
+            )}
+          </div>
+        )}
+        {sessionsState !== 'loading' && sessionsState !== 'error' && sessions.length === 0 && (
           <div style={{ textAlign: 'center', padding: '48px 20px', color: T.text3, fontSize: '0.8rem', lineHeight: 1.7 }}>
             No conversations yet.<br />Start a new chat!
           </div>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Pin } from 'lucide-react';
 import { MainShell } from '../components/common/MainShell';
 import { Sidebar as ChatSidebar } from '../components/chat/Sidebar';
@@ -8,58 +8,209 @@ import { ConnectionModal } from '../components/chat/ConnectionModal';
 import { T } from '../components/dashboard/tokens';
 import * as api from '../services/api';
 import type { ChatMessageView } from '../types/chat';
-import type { DatabaseConnection, SessionSummary } from '../types/api';
+import type { DatabaseConnection, SessionMessagesResponse, SessionSummary } from '../types/api';
+
+type LoadState = 'loading' | 'ready' | 'error';
+type MessageLoadState = 'idle' | LoadState;
+
+const CONNECTION_LOAD_ERROR = 'COULD NOT LOAD DATABASE CONNECTIONS';
+const SESSION_LOAD_ERROR = 'COULD NOT LOAD CONVERSATIONS';
+const MESSAGE_LOAD_ERROR = 'COULD NOT LOAD THIS CONVERSATION';
+const SEND_ERROR = 'QUERY REQUEST FAILED. PLEASE TRY AGAIN';
+
+function mapSessionMessages(data: SessionMessagesResponse): ChatMessageView[] {
+  return data.messages.map((message) => ({
+    id: message.id,
+    role: message.role as ChatMessageView['role'],
+    content: message.content,
+    sql: message.sql || undefined,
+    columns: message.columns || message.results?.columns || undefined,
+    rows: message.rows || message.results?.rows || undefined,
+    row_count: message.row_count ?? message.results?.row_count ?? undefined,
+    truncated: message.truncated ?? message.results?.truncated ?? undefined,
+    execution_time_ms: message.execution_time_ms ?? message.results?.execution_time_ms ?? undefined,
+    chart_recommendation: message.chart_recommendation || undefined,
+    column_metadata: message.column_metadata || undefined,
+    error: message.error || undefined,
+    is_pinned: message.is_pinned ?? false,
+    parent_id: message.parent_id || undefined,
+    prev_query_id: message.prev_query_id || undefined,
+  }));
+}
+
+function isUsageLimitError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('LIMIT_EXCEEDED') || message.includes('402');
+}
+
+function StatePanel({
+  title,
+  body,
+  tone = 'neutral',
+  actionLabel,
+  onAction,
+}: {
+  title: string;
+  body: string;
+  tone?: 'neutral' | 'error';
+  actionLabel?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '65vh', gap: 18, textAlign: 'center' }}>
+      <div style={{
+        width: 56,
+        height: 56,
+        borderRadius: 0,
+        background: tone === 'error' ? '#fee2e2' : '#1a1a1a',
+        border: tone === 'error' ? '1px solid #fecaca' : 'none',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '1.4rem',
+        fontWeight: 900,
+        color: tone === 'error' ? T.red : '#fff',
+        fontFamily: T.fontHead,
+        fontStyle: 'italic'
+      }}>Q</div>
+      <div style={{ fontFamily: T.fontMono, fontWeight: 900, fontSize: '0.8rem', color: tone === 'error' ? T.red : T.text, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+        {title}
+      </div>
+      <div style={{ fontSize: '0.95rem', color: T.text2, maxWidth: 430, lineHeight: 1.6 }}>
+        {body}
+      </div>
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          style={{
+            padding: '11px 18px',
+            borderRadius: 0,
+            border: `1px solid ${tone === 'error' ? '#fecaca' : 'rgba(0,0,0,0.12)'}`,
+            background: '#fff',
+            color: T.text,
+            cursor: 'pointer',
+            fontFamily: T.fontMono,
+            fontSize: '0.7rem',
+            fontWeight: 900,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase'
+          }}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
 
 export function ChatPage() {
   const [connections, setConnections] = useState<DatabaseConnection[]>([]);
+  const [connectionsState, setConnectionsState] = useState<LoadState>('loading');
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [activeConnectionId, setActiveConnectionId] = useState('');
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [sessionsState, setSessionsState] = useState<LoadState>('loading');
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMessageView[]>([]);
+  const [messagesState, setMessagesState] = useState<MessageLoadState>('idle');
+  const [messagesError, setMessagesError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
-  const [schemaOpen, setSchemaOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const skipNextFetch = useRef(false);
+  const messageLoadRequestRef = useRef(0);
 
-  useEffect(() => {
-    api.listConnections().then(conns => {
+  const loadConnections = useCallback(async (options: { preferLast?: boolean; preferredId?: string } = {}) => {
+    setConnectionsState('loading');
+    setConnectionError(null);
+    try {
+      const conns = await api.listConnections();
       setConnections(conns);
-      if (conns.length > 0) setActiveConnectionId(conns[0].id);
-    });
-    api.listSessions().then(setSessions);
+      setConnectionsState('ready');
+      setActiveConnectionId(current => {
+        if (options.preferredId && conns.some(c => c.id === options.preferredId)) return options.preferredId;
+        if (options.preferLast) return conns[conns.length - 1]?.id || '';
+        if (current && conns.some(c => c.id === current)) return current;
+        return conns[0]?.id || '';
+      });
+      return conns;
+    } catch (error) {
+      console.error('Failed to load connections:', error);
+      setConnectionsState('error');
+      setConnectionError(CONNECTION_LOAD_ERROR);
+      return [];
+    }
   }, []);
 
-  useEffect(() => {
-    if (!activeSessionId) { setMessages([]); return; }
-    if (skipNextFetch.current) { skipNextFetch.current = false; return; }
-    api.getSessionMessages(activeSessionId).then(data => {
-      const msgs: ChatMessageView[] = data.messages.map((message) => ({
-        id: message.id,
-        role: message.role as any,
-        content: message.content,
-        sql: message.sql || undefined,
-        columns: message.columns || message.results?.columns || undefined,
-        rows: message.rows || message.results?.rows || undefined,
-        row_count: message.row_count ?? message.results?.row_count ?? undefined,
-        execution_time_ms: message.execution_time_ms ?? message.results?.execution_time_ms ?? undefined,
-        chart_recommendation: message.chart_recommendation || undefined,
-        column_metadata: message.column_metadata || undefined,
-        error: message.error || undefined,
-        is_pinned: message.is_pinned ?? false,
-        parent_id: message.parent_id || undefined,
-        prev_query_id: message.prev_query_id || undefined,
-      }));
-      setMessages(msgs);
-      // Auto-switch to the session's last-used connection
+  const loadSessions = useCallback(async () => {
+    setSessionsState('loading');
+    setSessionsError(null);
+    try {
+      const nextSessions = await api.listSessions();
+      setSessions(nextSessions);
+      setSessionsState('ready');
+      return nextSessions;
+    } catch (error) {
+      console.error('Failed to load conversations:', error);
+      setSessionsState('error');
+      setSessionsError(SESSION_LOAD_ERROR);
+      return [];
+    }
+  }, []);
+
+  const loadMessages = useCallback(async (sessionId: string) => {
+    const requestId = messageLoadRequestRef.current + 1;
+    messageLoadRequestRef.current = requestId;
+    setMessagesState('loading');
+    setMessagesError(null);
+    setMessages([]);
+
+    try {
+      const data = await api.getSessionMessages(sessionId);
+      if (messageLoadRequestRef.current !== requestId) return;
+      setMessages(mapSessionMessages(data));
+      setMessagesState('ready');
       if (data.last_connection_id && connections.some(c => c.id === data.last_connection_id)) {
         setActiveConnectionId(data.last_connection_id);
       }
-    });
-  }, [activeSessionId, connections]); // Added connections to deps to ensure switch works when conns load
+    } catch (error) {
+      if (messageLoadRequestRef.current !== requestId) return;
+      console.error('Failed to load conversation messages:', error);
+      setMessages([]);
+      setMessagesState('error');
+      setMessagesError(MESSAGE_LOAD_ERROR);
+    }
+  }, [connections]);
 
-  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
+  useEffect(() => {
+    void loadConnections();
+    void loadSessions();
+  }, [loadConnections, loadSessions]);
+
+  useEffect(() => {
+    if (!activeSessionId) {
+      messageLoadRequestRef.current += 1;
+      setMessages([]);
+      setMessagesState('idle');
+      setMessagesError(null);
+      return;
+    }
+    if (skipNextFetch.current) {
+      skipNextFetch.current = false;
+      setMessagesState('ready');
+      setMessagesError(null);
+      return;
+    }
+    void loadMessages(activeSessionId);
+  }, [activeSessionId, loadMessages]);
+
+  useEffect(() => {
+    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
 
   const handleSqlSave = async (messageId: string, newSql: string) => {
     if (!activeSessionId || !activeConnectionId) return;
@@ -75,6 +226,7 @@ export function ChatPage() {
         rows: (updatedMsg as any).rows || (updatedMsg as any).results?.rows || undefined,
         columns: (updatedMsg as any).columns || (updatedMsg as any).results?.columns || undefined,
         chart_recommendation: (updatedMsg as any).chart_recommendation || undefined,
+        truncated: (updatedMsg as any).truncated ?? (updatedMsg as any).results?.truncated ?? undefined,
         execution_time_ms: (updatedMsg as any).execution_time_ms || (updatedMsg as any).results?.execution_time_ms || undefined,
         error: (updatedMsg as any).error || undefined,
         content: (updatedMsg as any).content || m.content,
@@ -96,8 +248,14 @@ export function ChatPage() {
   };
 
   const handleSend = async (message: string) => {
-    if (!activeConnectionId) return;
+    if (!activeConnectionId) {
+      setMessagesState('ready');
+      setMessages(prev => [...prev, { role: 'assistant', content: '', error: connectionsState === 'error' ? CONNECTION_LOAD_ERROR : 'CONNECT A DATABASE BEFORE CHATTING' }]);
+      return;
+    }
+
     const userMsg: ChatMessageView = { role: 'user', content: message };
+    setMessagesState('ready');
     setMessages(prev => [...prev, userMsg]);
     setLoading(true);
     try {
@@ -110,17 +268,17 @@ export function ChatPage() {
         columns: r.columns || [],
         rows: r.rows || [],
         row_count: r.row_count,
+        truncated: r.truncated,
         execution_time_ms: r.execution_time_ms,
         chart_recommendation: r.chart_recommendation || undefined,
         column_metadata: r.column_metadata || undefined,
         error: r.error || undefined,
         is_pinned: r.is_pinned ?? false,
-        parent_id: userMsg.id, // Direct link
+        parent_id: userMsg.id,
         prev_query_id: r.prev_query_id || undefined,
       };
       setMessages(prev => {
         const updated = [...prev];
-        // The last message in 'prev' is the user message we just added
         if (updated.length > 0 && updated[updated.length - 1].role === 'user') {
           updated[updated.length - 1] = {
             ...updated[updated.length - 1],
@@ -134,43 +292,62 @@ export function ChatPage() {
       if (!activeSessionId && r.session_id) {
         skipNextFetch.current = true;
         setActiveSessionId(r.session_id);
-        api.listSessions().then(setSessions);
+        void loadSessions();
       }
-    } catch (err: any) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('LIMIT_EXCEEDED') || msg.includes('402')) {
+    } catch (err) {
+      if (isUsageLimitError(err)) {
         setShowPaywall(true);
       } else {
-        setMessages(prev => [...prev, { role: 'assistant', content: '', error: msg }]);
+        setMessages(prev => [...prev, { role: 'assistant', content: '', error: SEND_ERROR }]);
       }
     } finally { setLoading(false); }
   };
 
-  const handleNewChat = () => { setActiveSessionId(null); setMessages([]); };
+  const handleNewChat = () => {
+    setActiveSessionId(null);
+    setMessages([]);
+    setMessagesState('idle');
+    setMessagesError(null);
+  };
+
   const handleDeleteSession = async (sid: string) => {
     await api.deleteSession(sid);
     setSessions(prev => prev.filter(s => s.id !== sid));
-    if (activeSessionId === sid) { setActiveSessionId(null); setMessages([]); }
+    if (activeSessionId === sid) handleNewChat();
   };
+
   const handleRenameSession = async (sid: string, title: string) => {
     await api.renameSession(sid, title);
     setSessions(prev => prev.map(s => s.id === sid ? { ...s, title } : s));
   };
+
   const handleRefreshConnections = () => {
-    api.listConnections().then(conns => {
-      setConnections(conns);
-      if (conns.length > 0 && !activeConnectionId) setActiveConnectionId(conns[0].id);
-      else if (conns.length > 0) setActiveConnectionId(conns[conns.length - 1].id);
-    });
+    void loadConnections({ preferLast: true });
   };
 
   const activeConn = connections.find(c => c.id === activeConnectionId);
   const activeSession = sessions.find(s => s.id === activeSessionId);
+  const chatInputDisabled = loading || connectionsState !== 'ready' || !activeConnectionId;
+  const chatInputDisabledReason = connectionsState === 'loading'
+    ? 'LOADING SOURCES'
+    : connectionsState === 'error'
+      ? 'SOURCE LOAD FAILED'
+      : connections.length === 0
+        ? 'CONNECT A DATABASE'
+        : !activeConnectionId
+          ? 'SELECT DATABASE'
+          : undefined;
+  const showConnectionLoading = connectionsState === 'loading' && connections.length === 0;
+  const showConnectionError = connectionsState === 'error' && connections.length === 0;
+  const showNoConnections = connectionsState === 'ready' && connections.length === 0;
+  const showMessageLoading = connectionsState === 'ready' && connections.length > 0 && messagesState === 'loading';
+  const showMessageError = connectionsState === 'ready' && connections.length > 0 && messagesState === 'error';
+  const showEmptyPrompt = connectionsState === 'ready' && connections.length > 0 && messagesState !== 'loading' && messagesState !== 'error' && messages.length === 0;
 
   return (
     <MainShell
       title={activeSession?.title || 'New Chat'}
-      subtitle={activeConn ? `${activeConn.db_type} • ${activeConn.database}` : 'Select a connection'}
+      subtitle={activeConn ? `${activeConn.db_type} - ${activeConn.database}` : 'Select a connection'}
       hideSidebar={true}
       hideHeader={true}
       activeId="chat"
@@ -179,32 +356,11 @@ export function ChatPage() {
         color: T.green,
         icon: <div style={{ width: 6, height: 6, borderRadius: '50%', background: T.green }} />
       } : undefined}
-      headerActions={
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => setSchemaOpen(!schemaOpen)}
-            style={{
-              display: 'flex', alignItems: 'center', gap: 6,
-              padding: '7px 14px', borderRadius: 8,
-              border: `1px solid ${schemaOpen ? T.accent : T.border}`,
-              background: schemaOpen ? T.accentDim : 'transparent',
-              color: schemaOpen ? T.accent : T.text2,
-              fontSize: '0.76rem', cursor: 'pointer', fontFamily: T.fontBody,
-              transition: 'all 0.18s ease',
-            }}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
-              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
-            </svg>
-            Schema {schemaOpen ? 'Open' : ''}
-          </button>
-        </div>
-      }
     >
       <div style={{ display: 'flex', width: '100%', height: '100%', overflow: 'hidden', position: 'relative' }}>
         <ChatSidebar
           sessions={sessions} activeSessionId={activeSessionId}
+          sessionsState={sessionsState} sessionsError={sessionsError} onRetrySessions={() => { void loadSessions(); }}
           onSelectSession={setActiveSessionId} onNewChat={handleNewChat}
           onDeleteSession={handleDeleteSession} onRenameSession={handleRenameSession}
           connections={connections} activeConnectionId={activeConnectionId}
@@ -219,7 +375,6 @@ export function ChatPage() {
           background: 'transparent',
           position: 'relative'
         }}>
-          {/* Main Stage (Messages + Centering Logic) */}
           <div style={{ flex: 1, display: 'flex', justifyContent: 'center', minWidth: 0, overflow: 'hidden' }}>
             <div
               id="chat-messages-scroll"
@@ -231,12 +386,11 @@ export function ChatPage() {
                 flexDirection: 'column',
                 overflowY: 'auto',
                 overflowX: 'hidden',
-                padding: '0 80px 40px', // Increased padding for editorial feel
+                padding: '0 80px 40px',
                 scrollBehavior: 'smooth'
               }}
             >
               <div style={{ width: '100%', minWidth: 0, paddingTop: 24 }}>
-                {/* Pinned Messages Bar - Editorial Style */}
                 {messages.filter(m => m.is_pinned).length > 0 && (
                   <div style={{ padding: '0 0 24px', borderBottom: `1px solid rgba(0,0,0,0.05)`, marginBottom: 32 }}>
                     <div style={{ fontSize: '0.62rem', fontWeight: 700, color: T.text3, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8, fontFamily: T.fontMono }}>
@@ -260,7 +414,7 @@ export function ChatPage() {
                             {m.content.length > 30 ? m.content.substring(0, 30) + '...' : m.content}
                           </div>
                           <div style={{ fontSize: '0.6rem', color: T.text3, fontFamily: T.fontMono, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-                            {m.rows?.length || 0} ROWS • {m.columns?.length || 0} COLS
+                            {m.rows?.length || 0} ROWS - {m.columns?.length || 0} COLS
                           </div>
                         </div>
                       ))}
@@ -268,7 +422,27 @@ export function ChatPage() {
                   </div>
                 )}
 
-                {messages.length === 0 && (
+                {showConnectionLoading && (
+                  <StatePanel title="LOADING DATABASE CONNECTIONS" body="Preparing your available data sources before chat starts." />
+                )}
+
+                {showConnectionError && (
+                  <StatePanel title="SOURCE LOAD FAILED" body={connectionError || CONNECTION_LOAD_ERROR} tone="error" actionLabel="RETRY LOAD" onAction={() => { void loadConnections(); }} />
+                )}
+
+                {showNoConnections && (
+                  <StatePanel title="NO DATABASE CONNECTIONS" body="Connect a PostgreSQL database before starting a chat." actionLabel="CONNECT DATABASE" onAction={() => setShowConnectModal(true)} />
+                )}
+
+                {showMessageLoading && (
+                  <StatePanel title="LOADING CONVERSATION" body="Restoring the selected conversation and its saved results." />
+                )}
+
+                {showMessageError && (
+                  <StatePanel title="CONVERSATION LOAD FAILED" body={messagesError || MESSAGE_LOAD_ERROR} tone="error" actionLabel="RETRY MESSAGE LOAD" onAction={() => { if (activeSessionId) void loadMessages(activeSessionId); }} />
+                )}
+
+                {showEmptyPrompt && (
                   <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '65vh', gap: 20 }}>
                     <div style={{
                       width: 64, height: 64, borderRadius: 0, background: '#1a1a1a',
@@ -288,12 +462,12 @@ export function ChatPage() {
                     </div>
                     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, marginTop: 16, justifyContent: 'center' }}>
                       {['Show me all tables', 'Describe the database', 'Who are the top customers?'].map(s => (
-                        <button key={s} onClick={() => handleSend(s)} disabled={!activeConnectionId || loading} style={{
+                        <button key={s} onClick={() => handleSend(s)} disabled={chatInputDisabled} style={{
                           padding: '10px 20px', borderRadius: 0, border: `1px solid rgba(0,0,0,0.1)`, background: '#fff',
-                          color: T.text, fontSize: '0.8rem', cursor: 'pointer', transition: 'all 0.2s', whiteSpace: 'nowrap',
+                          color: T.text, fontSize: '0.8rem', cursor: chatInputDisabled ? 'default' : 'pointer', transition: 'all 0.2s', whiteSpace: 'nowrap',
                           fontWeight: 700, fontFamily: T.fontMono, textTransform: 'uppercase', letterSpacing: '0.05em'
                         }}
-                          onMouseEnter={e => { e.currentTarget.style.borderColor = '#1a1a1a'; e.currentTarget.style.background = '#fdfcfb'; }}
+                          onMouseEnter={e => { if (!chatInputDisabled) { e.currentTarget.style.borderColor = '#1a1a1a'; e.currentTarget.style.background = '#fdfcfb'; } }}
                           onMouseLeave={e => { e.currentTarget.style.borderColor = 'rgba(0,0,0,0.1)'; e.currentTarget.style.background = '#fff'; }}
                         >{s}</button>
                       ))}
@@ -332,6 +506,7 @@ export function ChatPage() {
               <ChatInput
                 connections={connections} activeConnectionId={activeConnectionId}
                 onConnectionChange={setActiveConnectionId} onSend={handleSend} loading={loading}
+                disabled={chatInputDisabled} disabledReason={chatInputDisabledReason}
               />
             </div>
           </div>
@@ -340,7 +515,6 @@ export function ChatPage() {
 
       <ConnectionModal isOpen={showConnectModal} onClose={() => setShowConnectModal(false)} onConnected={handleRefreshConnections} />
 
-      {/* Paywall Overlay */}
       {showPaywall && (
         <div style={{
           position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
@@ -353,7 +527,7 @@ export function ChatPage() {
             padding: '40px 40px', maxWidth: 440, width: '100%', textAlign: 'center',
             boxShadow: '0 24px 64px rgba(0,0,0,0.5), 0 0 0 1px rgba(124,58,255,0.1) inset'
           }}>
-            <div style={{ fontSize: '3rem', marginBottom: 16 }}>⚡</div>
+            <div style={{ fontSize: '3rem', marginBottom: 16 }}>!</div>
             <h2 style={{ fontFamily: T.fontHead, fontWeight: 800, fontSize: '1.8rem', color: T.text, margin: '0 0 12px 0' }}>Usage Limit Reached</h2>
             <p style={{ fontSize: '0.95rem', color: T.text3, lineHeight: 1.6, margin: '0 0 32px 0' }}>
               You have hit your free tier limit for AI requests. Upgrade to Pro for unlimited AI analytics, background sync, and more.

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -155,10 +155,12 @@ export interface ChatMessageRecord {
     columns?: string[];
     rows?: Array<Record<string, unknown>>;
     row_count?: number | null;
+    truncated?: boolean | null;
     execution_time_ms?: number | null;
   } | null;
   rows?: Array<Record<string, unknown>> | null;
   row_count?: number | null;
+  truncated?: boolean | null;
   execution_time_ms?: number | null;
   column_metadata?: Record<string, string> | null;
   chart_recommendation?: ChartRecommendation | null;
@@ -198,6 +200,7 @@ export interface ChatResponse {
   columns: string[];
   rows: Array<Record<string, unknown>>;
   row_count: number;
+  truncated: boolean;
   execution_time_ms: number;
   chart_recommendation?: ChartRecommendation | null;
   error?: string | null;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -21,6 +21,9 @@ export interface ChatMessageView {
 export interface ChatSidebarProps {
   sessions: SessionSummary[];
   activeSessionId: string | null;
+  sessionsState?: 'loading' | 'ready' | 'error';
+  sessionsError?: string | null;
+  onRetrySessions?: () => void;
   onSelectSession: (id: string) => void;
   onNewChat: () => void;
   onDeleteSession: (id: string) => void;
@@ -35,6 +38,8 @@ export interface ChatInputProps {
   onConnectionChange: (id: string) => void;
   onSend: (message: string) => void;
   loading: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
 }
 
 export interface AddToDashboardMessage {

--- a/frontend/tests/chat-controls.test.tsx
+++ b/frontend/tests/chat-controls.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { MessageBubble } from '../src/components/chat/MessageBubble';
+import { ResultsTable } from '../src/components/chat/ResultsTable';
+import type { ChatMessageView } from '../src/types/chat';
+
+vi.mock('../src/hooks/useSmartSave', () => ({
+  useSmartSave: () => ({
+    smartAddToDashboard: vi.fn(),
+    smartSaveToLibrary: vi.fn(),
+    isSaving: false,
+  }),
+}));
+
+const assistantMessage: ChatMessageView = {
+  id: 'message_1',
+  role: 'assistant',
+  content: 'Here are the rows.',
+  sql: 'SELECT id FROM users',
+  columns: ['id'],
+  rows: [{ id: 1 }],
+  row_count: 1,
+  execution_time_ms: 12,
+  truncated: false,
+};
+
+describe('chat result controls', () => {
+  it('keeps real message actions and removes inactive controls', () => {
+    render(<MessageBubble message={assistantMessage} connectionId="conn_1" onTogglePin={vi.fn()} />);
+
+    expect(screen.getByText('COPY SQL')).toBeInTheDocument();
+    expect(screen.queryByText('COPY LINK')).not.toBeInTheDocument();
+    expect(screen.getByText('SAVE TO LIBRARY')).toBeInTheDocument();
+    expect(screen.getByText('ADD TO DASHBOARD')).toBeInTheDocument();
+    expect(screen.getByText('PIN RESULT')).toBeInTheDocument();
+    expect(screen.queryByText('REGENERATE')).not.toBeInTheDocument();
+  });
+
+  it('does not show inactive CSV or JSON export buttons', () => {
+    render(<ResultsTable columns={['id']} rows={[{ id: 1 }]} rowCount={1} executionTime={12} />);
+
+    expect(screen.getByText('RESULTS')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'CSV' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'JSON' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/chat-ui.test.tsx
+++ b/frontend/tests/chat-ui.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { ChatPage } from '../src/pages/ChatPage';
+import type { DatabaseConnection, SessionMessagesResponse, SessionSummary } from '../src/types/api';
+
+const apiMocks = vi.hoisted(() => ({
+  listConnections: vi.fn(),
+  listSessions: vi.fn(),
+  getSessionMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  deleteSession: vi.fn(),
+  renameSession: vi.fn(),
+  editSql: vi.fn(),
+  toggleMessagePin: vi.fn(),
+}));
+
+vi.mock('../src/services/api', () => apiMocks);
+vi.mock('../src/components/common/MainShell', () => ({
+  MainShell: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}));
+vi.mock('../src/components/chat/MessageBubble', () => ({
+  MessageBubble: ({ message }: { message: { content: string; error?: string } }) => (
+    <div>{message.error || message.content}</div>
+  ),
+}));
+vi.mock('../src/components/chat/ConnectionModal', () => ({
+  ConnectionModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div>CONNECTION MODAL MOCK</div> : null,
+}));
+
+const connection: DatabaseConnection = {
+  id: 'conn_1',
+  name: 'Analytics DB',
+  db_type: 'postgresql',
+  database: 'analytics',
+  host: 'db.example.com',
+  port: 5432,
+  username: 'reader',
+  status: 'live',
+  health_state: 'live',
+  tables_count: 3,
+  last_status: 'healthy',
+};
+
+const session: SessionSummary = {
+  id: 'session_1',
+  connection_ids: ['conn_1'],
+  last_connection_id: 'conn_1',
+  title: 'Revenue check',
+  message_count: 2,
+  created_at: new Date().toISOString(),
+};
+
+const messagesResponse: SessionMessagesResponse = {
+  session_id: 'session_1',
+  connection_ids: ['conn_1'],
+  last_connection_id: 'conn_1',
+  messages: [
+    {
+      id: 'message_1',
+      role: 'assistant',
+      content: 'Assistant answer',
+      timestamp: new Date().toISOString(),
+    },
+  ],
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('chat bootstrap states', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    apiMocks.listConnections.mockResolvedValue([connection]);
+    apiMocks.listSessions.mockResolvedValue([]);
+    apiMocks.getSessionMessages.mockResolvedValue(messagesResponse);
+  });
+
+  it('shows connection loading state during initial bootstrap', async () => {
+    const pendingConnections = deferred<DatabaseConnection[]>();
+    apiMocks.listConnections.mockReturnValue(pendingConnections.promise);
+
+    render(<ChatPage />);
+
+    expect(screen.getByText('LOADING DATABASE CONNECTIONS')).toBeInTheDocument();
+
+    pendingConnections.resolve([connection]);
+    await screen.findByText(/What would you/i);
+  });
+
+  it('shows connection load failure with retry', async () => {
+    const user = userEvent.setup();
+    apiMocks.listConnections
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce([connection]);
+
+    render(<ChatPage />);
+
+    expect((await screen.findAllByText('SOURCE LOAD FAILED')).length).toBeGreaterThan(0);
+    expect(screen.getByText('COULD NOT LOAD DATABASE CONNECTIONS')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'RETRY LOAD' }));
+
+    expect(await screen.findByText(/What would you/i)).toBeInTheDocument();
+    expect(apiMocks.listConnections).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows no-connection CTA and opens the connection modal', async () => {
+    const user = userEvent.setup();
+    apiMocks.listConnections.mockResolvedValue([]);
+
+    render(<ChatPage />);
+
+    expect(await screen.findByText('NO DATABASE CONNECTIONS')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('CONNECT A DATABASE')).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'CONNECT DATABASE' }));
+
+    expect(screen.getByText('CONNECTION MODAL MOCK')).toBeInTheDocument();
+  });
+
+  it('shows sidebar session failure with retry', async () => {
+    const user = userEvent.setup();
+    apiMocks.listSessions
+      .mockRejectedValueOnce(new Error('session service down'))
+      .mockResolvedValueOnce([session]);
+
+    render(<ChatPage />);
+
+    expect(await screen.findByText('CONVERSATION LOAD FAILED')).toBeInTheDocument();
+    expect(screen.getByText('COULD NOT LOAD CONVERSATIONS')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'RETRY CONVERSATIONS' }));
+
+    expect(await screen.findByText('Revenue check')).toBeInTheDocument();
+    expect(apiMocks.listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows message loading while a conversation is selected', async () => {
+    const user = userEvent.setup();
+    const pendingMessages = deferred<SessionMessagesResponse>();
+    apiMocks.listSessions.mockResolvedValue([session]);
+    apiMocks.getSessionMessages.mockReturnValue(pendingMessages.promise);
+
+    render(<ChatPage />);
+
+    await user.click(await screen.findByText('Revenue check'));
+
+    expect(screen.getByText('LOADING CONVERSATION')).toBeInTheDocument();
+
+    pendingMessages.resolve(messagesResponse);
+    expect(await screen.findByText('Assistant answer')).toBeInTheDocument();
+  });
+
+  it('shows message load failure with retry', async () => {
+    const user = userEvent.setup();
+    apiMocks.listSessions.mockResolvedValue([session]);
+    apiMocks.getSessionMessages
+      .mockRejectedValueOnce(new Error('message load failed'))
+      .mockResolvedValueOnce(messagesResponse);
+
+    render(<ChatPage />);
+
+    await user.click(await screen.findByText('Revenue check'));
+
+    expect(await screen.findByText('COULD NOT LOAD THIS CONVERSATION')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'RETRY MESSAGE LOAD' }));
+
+    expect(await screen.findByText('Assistant answer')).toBeInTheDocument();
+    expect(apiMocks.getSessionMessages).toHaveBeenCalledTimes(2);
+  });
+
+
+  it('enforces the visible 2048 character message limit in the input', async () => {
+    render(<ChatPage />);
+
+    const input = await screen.findByPlaceholderText('What would you like to know?');
+
+    expect(input).toHaveAttribute('maxLength', '2048');
+  });
+  it('disables chat send when no active connection exists', async () => {
+    apiMocks.listConnections.mockResolvedValue([]);
+
+    render(<ChatPage />);
+
+    expect(await screen.findByText('NO DATABASE CONNECTIONS')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('CONNECT A DATABASE')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- harden chat SQL execution with server-side row caps, truncation metadata, and edit-SQL preflight validation
- add backend request validation for chat messages and edited SQL payloads
- improve chat frontend bootstrap states for loading, errors, empty connections, retries, and disabled send behavior
- add backend and frontend regression tests for the new behavior

## Why

The chat SQL agent flow needed stronger product-quality guardrails. Before this change, row limits could be bypassed by SQL that already had a LIMIT, edit-SQL could execute before proving the target message was valid, chat request payloads were too loose, and the frontend could show misleading blank states during bootstrap failures.

## Validation

- `cd backend && python -m pytest tests -q` -> 120 passed
- `cd frontend && npm.cmd run test` -> 13 passed
- `cd frontend && npm.cmd run build` -> passed, with existing large bundle warning
- `git diff --check` -> passed

## Notes

Docs were intentionally kept out of this PR and remain untracked locally.